### PR TITLE
Bugfixes, Run Notebooks again and variable name changes

### DIFF
--- a/ci/tests/test_benchmark/test_classification/test_classifier.py
+++ b/ci/tests/test_benchmark/test_classification/test_classifier.py
@@ -23,6 +23,7 @@ def test_load_model__ok_nn_head():
     assert scgpt_loaded_nn.base_model == scgpt
     assert scgpt_loaded_nn.trained_task_model == saved_nn_head
     assert scgpt_loaded_nn.name == name
+    assert scgpt_loaded_nn.gene_col_name == "index"
 
 
 def test_load_model__ok_custom_head():
@@ -47,6 +48,7 @@ def test_load_model__ok_custom_head():
     assert scgpt_loaded_nn.base_model == scgpt
     assert scgpt_loaded_nn.trained_task_model == custom_head
     assert scgpt_loaded_nn.name == name
+    assert scgpt_loaded_nn.gene_col_name == "index"
 
 def test_load_model__nok_custom_head():
     """
@@ -89,6 +91,7 @@ def test_load_model__ok_custom_base():
     assert custom_base_classifier.base_model == custom_base
     assert custom_base_classifier.trained_task_model == saved_nn_head
     assert custom_base_classifier.name == name
+    assert custom_base_classifier.gene_col_name == "index"
 
 def test_load_model__nok_custom_base():
     """
@@ -128,7 +131,8 @@ def test_train_classifier_head(mocker):
     assert isinstance(scgpt_nn_c, Classifier)
     assert scgpt_nn_c.base_model == scgpt
     assert scgpt_nn_c.name == f"{scgpt.__class__.__name__} with {head.__class__.__name__}"
-    assert scgpt_nn_c.trained_task_model == head       
+    assert scgpt_nn_c.trained_task_model == head 
+    assert scgpt_nn_c.gene_col_name == "index"      
 
 
 def test_check_validity_for_training_wrong_column_label_name():
@@ -176,4 +180,5 @@ def test_get_predictions_w_no_base_model(mocker):
     assert isinstance(c, Classifier)
     assert c.base_model == None
     assert c.name == name
-    assert c.trained_task_model == standalone       
+    assert c.trained_task_model == standalone   
+    assert c.gene_col_name == "index"    

--- a/ci/tests/test_geneformer/test_geneformer_model.py
+++ b/ci/tests/test_geneformer/test_geneformer_model.py
@@ -15,7 +15,7 @@ class TestGeneformerModel:
     data.obs["n_counts"] = [1]
     data.obs["cell_type"] = ["CD4 T cells"]
     data.X = [[1, 2, 5]]
-    tokenized_dataset = geneformer.process_data(data, gene_column_name='gene_symbols')
+    tokenized_dataset = geneformer.process_data(data, gene_names='gene_symbols')
 
     def test_process_data_mapping_to_ensemble_ids(self):
         assert self.data.var['ensembl_id'][0] == 'ENSG00000187634'

--- a/ci/tests/test_scgpt/test_scgpt_model.py
+++ b/ci/tests/test_scgpt/test_scgpt_model.py
@@ -22,12 +22,12 @@ class TestSCGPTModel:
     data.X = [[1, 2, 5, 6, 0]]
     
     def test_process_data(self):
-        dataset = self.scgpt.process_data(self.data, gene_column_name = "gene_names")
+        dataset = self.scgpt.process_data(self.data, gene_names = "gene_names")
 
-        assert self.scgpt.gene_column_name == "gene_names"
-        assert self.scgpt.gene_column_name in self.data.var
+        assert self.scgpt.gene_names == "gene_names"
+        assert self.scgpt.gene_names in self.data.var
 
-        # asserts that all the genes in gene_column_name have been correctly translated 
+        # asserts that all the genes in gene_names have been correctly translated 
         # to the corresponding ids based on the vocabulary
         assert (self.data.var["id_in_vocab"] == [0, 1, -1, 3, 2]).all()
 
@@ -43,26 +43,26 @@ class TestSCGPTModel:
     def test_correct_handling_of_batch_ids(self):
         batch_id_array = [1]
         self.data.obs["batch_id"] = batch_id_array
-        dataset = self.scgpt.process_data(self.data, gene_column_name = "gene_names", use_batch_labels=True)
+        dataset = self.scgpt.process_data(self.data, gene_names = "gene_names", use_batch_labels=True)
         assert (dataset.batch_ids == batch_id_array).all()
 
     def test_direct_assignment_of_genes_to_index(self):
         self.data.var.index = ['SAMD11', 'PLEKHN1', "NOT_IN_VOCAB", "<pad>", 'HES4']
-        self.scgpt.process_data(self.data, gene_column_name = "index")
+        self.scgpt.process_data(self.data, gene_names = "index")
         
         # as set above, the gene column can also be direclty assigned to the index column
-        assert self.scgpt.gene_column_name == "index"
-        assert self.scgpt.gene_column_name in self.data.var
+        assert self.scgpt.gene_names == "index"
+        assert self.scgpt.gene_names in self.data.var
 
 
     def test_get_embeddings(self):
-        dataset = self.scgpt.process_data(self.data, gene_column_name = "gene_names")
+        dataset = self.scgpt.process_data(self.data, gene_names = "gene_names")
         embeddings = self.scgpt.get_embeddings(dataset)
         assert embeddings.shape == (1, 512)
 
     dummy_data = AnnData()
     dummy_data.var.index = ['gene1', 'gene2', 'gene3']
-    @pytest.mark.parametrize("data, gene_column_name, batch_labels", 
+    @pytest.mark.parametrize("data, gene_names, batch_labels", 
                              [
                                 #  missing gene_names in data.var
                                 (AnnData(), "gene_names", False),
@@ -70,6 +70,6 @@ class TestSCGPTModel:
                                 (dummy_data, "index", True),
                              ]
     )
-    def test_check_data_validity(self, data, gene_column_name, batch_labels):
+    def test_check_data_validity(self, data, gene_names, batch_labels):
         with pytest.raises(KeyError):
-            self.scgpt.check_data_validity(data, gene_column_name, batch_labels)
+            self.scgpt.check_data_validity(data, gene_names, batch_labels)

--- a/examples/notebooks/Cell-Type-Annotation.ipynb
+++ b/examples/notebooks/Cell-Type-Annotation.ipynb
@@ -49,7 +49,7 @@
       ],
       "source": [
         "!pip install tensorflow_addons\n",
-        "!pip install git+https://github.com/helicalAI/helical.git@develop | tail -n 1"
+        "!pip install git+https://github.com/helicalAI/helical.git@main | tail -n 1"
       ]
     },
     {
@@ -1047,7 +1047,7 @@
         "geneformer_config = GeneformerConfig(batch_size=50, device=device)\n",
         "geneformer = Geneformer(configurer = geneformer_config)\n",
         "\n",
-        "data_geneformer = geneformer.process_data(adata, use_gene_symbols=False)\n",
+        "data_geneformer = geneformer.process_data(adata, gene_column_name = \"ensembl_id\")\n",
         "x_geneformer = geneformer.get_embeddings(data_geneformer)\n",
         "x_geneformer.shape"
       ]
@@ -1295,7 +1295,7 @@
         "adata_unseen.var[\"ensembl_id\"] = adata_unseen.var[\"index_column\"]\n",
         "adata_unseen.obs['n_counts'] = adata_unseen.X.sum(axis=1)\n",
         "adata_unseen.obs['cell_type'] = adata_unseen.obs['celltype']\n",
-        "data_unseen_geneformer = geneformer.process_data(adata_unseen, use_gene_symbols=False)\n",
+        "data_unseen_geneformer = geneformer.process_data(adata_unseen, gene_column_name = \"ensembl_id\")\n",
         "x_unseen_geneformer = geneformer.get_embeddings(data_unseen_geneformer)\n",
         "predictions_nn_unseen_geneformer = head_model.predict(x_unseen_geneformer)"
       ]

--- a/examples/notebooks/Cell-Type-Annotation.ipynb
+++ b/examples/notebooks/Cell-Type-Annotation.ipynb
@@ -621,7 +621,7 @@
         "log_dir = \"logs/fit/\" + datetime.datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
         "tensorboard_callback = TensorBoard(log_dir=log_dir, histogram_freq=1)\n",
         "\n",
-        "history = head_model.fit(X_train, y_train, epochs=50, batch_size=64, validation_data=(X_test, y_test), callbacks=[tensorboard_callback])"
+        "history = head_model_scgpt.fit(X_train, y_train, epochs=50, batch_size=64, validation_data=(X_test, y_test), callbacks=[tensorboard_callback])"
       ]
     },
     {
@@ -644,7 +644,7 @@
         }
       ],
       "source": [
-        "predictions_nn = head_model.predict(X_test)\n",
+        "predictions_nn = head_model_scgpt.predict(X_test)\n",
         "y_pred = np.argmax(predictions_nn, axis=1)\n",
         "y_true = np.argmax(y_test, axis=1)"
       ]
@@ -773,7 +773,7 @@
         "adata_unseen = sc.read(\"ms_default.h5ad\")\n",
         "data_unseen = scgpt.process_data(adata_unseen, gene_names=\"gene_name\")\n",
         "x_unseen = scgpt.get_embeddings(data_unseen)\n",
-        "predictions_nn_unseen = head_model.predict(x_unseen)"
+        "predictions_nn_unseen = head_model_scgpt.predict(x_unseen)"
       ]
     },
     {
@@ -1184,14 +1184,14 @@
         }
       ],
       "source": [
-        "head_model_scgpt = head_model\n",
+        "head_model_geneformer = head_model\n",
         "X_train, X_test, y_train, y_test = train_test_split(x_geneformer, y_encoded, test_size=0.1, random_state=42)\n",
         "\n",
         "# Setup callbacks\n",
         "log_dir = \"logs/fit/\" + datetime.datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
         "tensorboard_callback = TensorBoard(log_dir=log_dir, histogram_freq=1)\n",
         "\n",
-        "history = head_model.fit(X_train, y_train, epochs=50, batch_size=64, validation_data=(X_test, y_test), callbacks=[tensorboard_callback])"
+        "history = head_model_geneformer.fit(X_train, y_train, epochs=50, batch_size=64, validation_data=(X_test, y_test), callbacks=[tensorboard_callback])"
       ]
     },
     {
@@ -1297,7 +1297,7 @@
         "adata_unseen.obs['cell_type'] = adata_unseen.obs['celltype']\n",
         "data_unseen_geneformer = geneformer.process_data(adata_unseen, gene_names = \"ensembl_id\")\n",
         "x_unseen_geneformer = geneformer.get_embeddings(data_unseen_geneformer)\n",
-        "predictions_nn_unseen_geneformer = head_model.predict(x_unseen_geneformer)"
+        "predictions_nn_unseen_geneformer = head_model_geneformer.predict(x_unseen_geneformer)"
       ]
     },
     {

--- a/examples/notebooks/Cell-Type-Annotation.ipynb
+++ b/examples/notebooks/Cell-Type-Annotation.ipynb
@@ -374,7 +374,7 @@
         "\n",
         "scgpt_config = scGPTConfig(batch_size=50, device=device)\n",
         "scgpt = scGPT(configurer = scgpt_config)\n",
-        "data = scgpt.process_data(adata, gene_column_name = \"gene_name\")\n",
+        "data = scgpt.process_data(adata, gene_names = \"gene_name\")\n",
         "x_scgpt = scgpt.get_embeddings(data)\n",
         "x_scgpt.shape"
       ]
@@ -771,7 +771,7 @@
       ],
       "source": [
         "adata_unseen = sc.read(\"ms_default.h5ad\")\n",
-        "data_unseen = scgpt.process_data(adata_unseen, gene_column_name=\"gene_name\")\n",
+        "data_unseen = scgpt.process_data(adata_unseen, gene_names=\"gene_name\")\n",
         "x_unseen = scgpt.get_embeddings(data_unseen)\n",
         "predictions_nn_unseen = head_model.predict(x_unseen)"
       ]
@@ -1047,7 +1047,7 @@
         "geneformer_config = GeneformerConfig(batch_size=50, device=device)\n",
         "geneformer = Geneformer(configurer = geneformer_config)\n",
         "\n",
-        "data_geneformer = geneformer.process_data(adata, gene_column_name = \"ensembl_id\")\n",
+        "data_geneformer = geneformer.process_data(adata, gene_names = \"ensembl_id\")\n",
         "x_geneformer = geneformer.get_embeddings(data_geneformer)\n",
         "x_geneformer.shape"
       ]
@@ -1295,7 +1295,7 @@
         "adata_unseen.var[\"ensembl_id\"] = adata_unseen.var[\"index_column\"]\n",
         "adata_unseen.obs['n_counts'] = adata_unseen.X.sum(axis=1)\n",
         "adata_unseen.obs['cell_type'] = adata_unseen.obs['celltype']\n",
-        "data_unseen_geneformer = geneformer.process_data(adata_unseen, gene_column_name = \"ensembl_id\")\n",
+        "data_unseen_geneformer = geneformer.process_data(adata_unseen, gene_names = \"ensembl_id\")\n",
         "x_unseen_geneformer = geneformer.get_embeddings(data_unseen_geneformer)\n",
         "predictions_nn_unseen_geneformer = head_model.predict(x_unseen_geneformer)"
       ]

--- a/examples/notebooks/Geneformer-vs-UCE.ipynb
+++ b/examples/notebooks/Geneformer-vs-UCE.ipynb
@@ -249,8 +249,8 @@
     "# The \"process_data\"-function from the Helical package pre-processes the data. \n",
     "# It takes AnnData as an input. \n",
     "# More information in our documentation\n",
-    "train_dataset = geneformer.process_data(X_train,nproc=1)\n",
-    "test_dataset = geneformer.process_data(X_test,nproc=1)"
+    "train_dataset = geneformer.process_data(X_train, nproc=1, gene_column_name=\"gene_symbols\")\n",
+    "test_dataset = geneformer.process_data(X_test, nproc=1, gene_column_name=\"gene_symbols\")"
    ]
   },
   {

--- a/examples/notebooks/Geneformer-vs-UCE.ipynb
+++ b/examples/notebooks/Geneformer-vs-UCE.ipynb
@@ -249,8 +249,8 @@
     "# The \"process_data\"-function from the Helical package pre-processes the data. \n",
     "# It takes AnnData as an input. \n",
     "# More information in our documentation\n",
-    "train_dataset = geneformer.process_data(X_train, nproc=1, gene_column_name=\"gene_symbols\")\n",
-    "test_dataset = geneformer.process_data(X_test, nproc=1, gene_column_name=\"gene_symbols\")"
+    "train_dataset = geneformer.process_data(X_train, nproc=1, gene_names=\"gene_symbols\")\n",
+    "test_dataset = geneformer.process_data(X_test, nproc=1, gene_names=\"gene_symbols\")"
    ]
   },
   {

--- a/examples/notebooks/Quick-Start-Tutorial.ipynb
+++ b/examples/notebooks/Quick-Start-Tutorial.ipynb
@@ -287,7 +287,7 @@
     }
    ],
    "source": [
-    "dataset = geneformer.process_data(ann_data[:100], nproc=1, gene_column_name=\"gene_symbols\", custom_attr_name_dict={\"cell_type\": \"cell_type\"})"
+    "dataset = geneformer.process_data(ann_data[:100], nproc=1, gene_names=\"gene_symbols\", custom_attr_name_dict={\"cell_type\": \"cell_type\"})"
    ]
   },
   {

--- a/examples/notebooks/Quick-Start-Tutorial.ipynb
+++ b/examples/notebooks/Quick-Start-Tutorial.ipynb
@@ -287,7 +287,7 @@
     }
    ],
    "source": [
-    "dataset = geneformer.process_data(ann_data[:100],nproc=1)"
+    "dataset = geneformer.process_data(ann_data[:100], nproc=1, gene_column_name=\"gene_symbols\", custom_attr_name_dict={\"cell_type\": \"cell_type\"})"
    ]
   },
   {

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -72,7 +72,7 @@ class Geneformer(HelicalRNAModel):
         
     def process_data(self, 
                      adata: AnnData,  
-                     gene_column_name: str = "ensembl_id", 
+                     gene_names: str = "ensembl_id", 
                      nproc: int = 1, 
                      output_path: Optional[str] = None,
                      custom_attr_name_dict: Optional[dict] = None) -> Dataset:   
@@ -84,13 +84,13 @@ class Geneformer(HelicalRNAModel):
             The AnnData object containing the data to be processed. It is important to note that the Geneformer uses Ensembl IDs to identify genes.
             Currently the Geneformer only supports human genes.
             If you already have the ensembl_id column, you can skip the mapping step.
-        gene_column_name: str, optional, default = "ensembl_id"
+        gene_names: str, optional, default = "ensembl_id"
             The column in adata.var that contains the gene names. If you set this string to something other than "ensembl_id", 
             we will map the gene symbols in that column to Ensembl IDs with a mapping taken from the `Ensembl Website https://www.ensembl.org/`.
             If it is left at "ensembl_id", there will be no mapping.
             If this variable is set to "index", the index of the AnnData object will be used and mapped to Ensembl IDs.
             In the special case where the data has Ensemble IDs as the index, and you pass "index". This would result in invalid mappings.
-            In that case, it is recommended to create a new column with the Ensemble IDs in the data and pass "ensembl_id" as the gene_column_name.
+            In that case, it is recommended to create a new column with the Ensemble IDs in the data and pass "ensembl_id" as the gene_names.
         nproc : int, optional, default = 1
             Number of processes to use for dataset processing.
         output_path : str, default = None
@@ -107,7 +107,7 @@ class Geneformer(HelicalRNAModel):
             The tokenized dataset in the form of a Hugginface Dataset object.
             
         """ 
-        self.check_data_validity(adata, gene_column_name)
+        self.check_data_validity(adata, gene_names)
 
         files_config = {
             "mapping_path": self.config.model_dir / "human_gene_to_ensemble_id.pkl",
@@ -116,9 +116,9 @@ class Geneformer(HelicalRNAModel):
         }
 
         # map gene symbols to ensemble ids if provided
-        if gene_column_name != "ensembl_id":          
+        if gene_names != "ensembl_id":          
             mappings = pkl.load(open(files_config["mapping_path"], 'rb'))
-            adata.var['ensembl_id'] = adata.var[gene_column_name].apply(lambda x: mappings.get(x,{"id":None})['id'])
+            adata.var['ensembl_id'] = adata.var[gene_names].apply(lambda x: mappings.get(x,{"id":None})['id'])
             non_none_mappings = adata.var['ensembl_id'].notnull().sum()
             LOGGER.info(f"Mapped {non_none_mappings} genes to Ensembl IDs from a total of {adata.var.shape[0]} genes.")
 
@@ -167,14 +167,14 @@ class Geneformer(HelicalRNAModel):
         return embeddings
 
 
-    def check_data_validity(self, adata: AnnData, gene_column_name: str) -> None:
+    def check_data_validity(self, adata: AnnData, gene_names: str) -> None:
         """Checks if the data is eligible for processing by the Geneformer model  
 
         Parameters
         ----------
         adata : AnnData
             The AnnData object containing the data to be processed.
-        gene_column_name: str
+        gene_names: str
             The column in adata.var that contains the gene names.
 
         Raises
@@ -182,7 +182,7 @@ class Geneformer(HelicalRNAModel):
         KeyError
             If the data is missing column names.
         """
-        self.check_rna_data_validity(adata, gene_column_name)
+        self.check_rna_data_validity(adata, gene_names)
 
         if not 'n_counts' in adata.obs.columns.to_list():
             message = f"Data must have the 'obs' keys 'n_counts' to be processed by the Geneformer model."

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -74,7 +74,8 @@ class Geneformer(HelicalRNAModel):
                      adata: AnnData,  
                      gene_column_name: str = "ensembl_id", 
                      nproc: int = 1, 
-                     output_path: Optional[str] = None) -> Dataset:   
+                     output_path: Optional[str] = None,
+                     custom_attr_name_dict: Optional[dict] = None) -> Dataset:   
         """Processes the data for the UCE model
 
         Parameters 
@@ -94,7 +95,11 @@ class Geneformer(HelicalRNAModel):
             Number of processes to use for dataset processing.
         output_path : str, default = None
             Whether to save the tokenized dataset to the specified output_path.
-
+        custom_attr_name_dict : dict, optional, default = None
+            A dictionary that contains the names of the custom attributes to be added to the dataset. 
+            The keys of the dictionary are the names of the custom attributes, and the values are the names of the columns in adata.obs. 
+            For example, if you want to add a custom attribute called "cell_type" to the dataset, you would pass custom_attr_name_dict = {"cell_type": "cell_type"}.
+            If you do not want to add any custom attributes, you can leave this parameter as None.
 
         Returns
         -------
@@ -122,7 +127,8 @@ class Geneformer(HelicalRNAModel):
             self.gene_token_dict = pickle.load(f)
             self.pad_token_id = self.gene_token_dict.get("<pad>")
 
-        self.tk = TranscriptomeTokenizer(nproc=nproc, 
+        self.tk = TranscriptomeTokenizer(custom_attr_name_dict=custom_attr_name_dict,
+                                         nproc=nproc, 
                                          gene_median_file = files_config["gene_median_path"], 
                                          token_dictionary_file = files_config["token_path"])
 

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -76,7 +76,7 @@ class Geneformer(HelicalRNAModel):
                      nproc: int = 1, 
                      output_path: Optional[str] = None,
                      custom_attr_name_dict: Optional[dict] = None) -> Dataset:   
-        """Processes the data for the UCE model
+        """Processes the data for the Geneformer model
 
         Parameters 
         ----------

--- a/helical/models/uce/model.py
+++ b/helical/models/uce/model.py
@@ -69,7 +69,7 @@ class UCE(HelicalRNAModel):
 
     def process_data(self, 
                      adata: AnnData, 
-                     gene_column_name: str = "index",
+                     gene_names: str = "index",
                      species: str = "human", 
                      filter_genes_min_cell: int = None, 
                      embedding_model: str = "ESM2" ) -> UCEDataset:
@@ -80,7 +80,7 @@ class UCE(HelicalRNAModel):
         adata : AnnData
             The AnnData object containing the data to be processed. 
             The UCE model requires the gene expression data as input and the gene symbols as variable names (i.e. as adata.var_names).
-        gene_column_name: str, optional, default = "index"
+        gene_names: str, optional, default = "index"
             The name of the column in the AnnData object that contains the gene symbols.
             By default, the index of the AnnData object is used.
             If another column is specified, that column will be set as the index of the AnnData object.
@@ -97,10 +97,10 @@ class UCE(HelicalRNAModel):
             Inherits from Dataset class.
         """
                 
-        self.check_rna_data_validity(adata, gene_column_name)
+        self.check_rna_data_validity(adata, gene_names)
 
-        if gene_column_name != "index":
-            adata.var.index = adata.var[gene_column_name]
+        if gene_names != "index":
+            adata.var.index = adata.var[gene_names]
 
         files_config = {
             "spec_chrom_csv_path": self.model_dir / "species_chrom.csv",


### PR DESCRIPTION
- Fix bug where one could not set the gene_column_name to make a prediction with the Classifier class
- Fix notebooks
- Fix Geneformer dataset creation where a custom dictionary key can be passed so that the resulting `Dataset` (after process_data) has the specified key
- Rename variable `gene_column_name` to `gene_names`