### PR TITLE
Geneformer v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,13 +47,13 @@ jobs:
       #     pytest-coverage-path: ./pytest-coverage.txt
       #     junitxml-path: ./pytest.xml
 
-      - name: Execute Geneformer
+      - name: Execute Geneformer v1
         run: |
-          python examples/run_models/run_geneformer.py
+          python examples/run_models/run_geneformer.py +model_name="gf-12L-30M-i2048"
 
-      - name: Execute Geneformer
+      - name: Execute Geneformer v2
         run: |
-          python examples/run_models/run_geneformer.py --config-name geneformer_config_v2
+          python examples/run_models/run_geneformer.py +model_name="gf-12L-95M-i4096"
 
       - name: Execute scGPT
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,11 +49,11 @@ jobs:
 
       - name: Execute Geneformer v1
         run: |
-          python examples/run_models/run_geneformer.py +model_name="gf-12L-30M-i2048"
+          python examples/run_models/run_geneformer.py ++model_name="gf-12L-30M-i2048"
 
       - name: Execute Geneformer v2
         run: |
-          python examples/run_models/run_geneformer.py +model_name="gf-12L-95M-i4096"
+          python examples/run_models/run_geneformer.py ++model_name="gf-12L-95M-i4096"
 
       - name: Execute scGPT
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           pytest --cov-report=html:html_cov --cov-branch --cov-report term --cov=helical ci/
       
       - name: Upload coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: html_cov/

--- a/ci/download_all.py
+++ b/ci/download_all.py
@@ -1,6 +1,51 @@
 from helical.services.downloader import Downloader
 from pathlib import Path
 
+
+def download_geneformer_models():
+    downloader = Downloader()
+    versions = ['v1', 'v2']
+
+    # We can decide to download more models by simply adding the model names from the full list as reported in geneformer_config.py
+    version_models_dict = {
+        "v1": ["gf-12L-30M-i2048"],
+        "v2": ["gf-12L-95M-i4096"]
+    }
+    
+    for version in versions:
+        # Download common files for each version
+        common_files = [
+            f"geneformer/{version}/gene_median_dictionary.pkl",
+            f"geneformer/{version}/token_dictionary.pkl",
+            f"geneformer/{version}/ensembl_mapping_dict.pkl",
+        ]
+        for file in common_files:
+            downloader.download_via_name(file)
+        
+        # Get all model directories
+        model_dirs = version_models_dict[version]
+        
+        for model_name in model_dirs:
+            model_files = [
+                f"geneformer/{version}/{model_name}/config.json",
+                f"geneformer/{version}/{model_name}/training_args.bin",
+            ]
+            
+            # Add version-specific files
+            if version == 'v2':
+                model_files.extend([
+                    f"geneformer/{version}/{model_name}/generation_config.json",
+                    f"geneformer/{version}/{model_name}/model.safetensors",
+                ])
+            else:
+                model_files.append(f"geneformer/{version}/{model_name}/pytorch_model.bin")
+            
+            # Download all files for the current model
+            for file in model_files:
+                downloader.download_via_name(file)
+    
+    print("All Geneformer models and files have been downloaded.")
+
 def main():
     downloader = Downloader()
     downloader.display = False
@@ -15,11 +60,12 @@ def main():
     downloader.download_via_name("scgpt/scGPT_CP/vocab.json")
     downloader.download_via_name("scgpt/scGPT_CP/best_model.pt")
 
-    downloader.download_via_name("geneformer/gene_median_dictionary.pkl")
-    downloader.download_via_name("geneformer/token_dictionary.pkl")
-    downloader.download_via_name("geneformer/geneformer-12L-30M/config.json")
-    downloader.download_via_name("geneformer/geneformer-12L-30M/pytorch_model.bin")
-    downloader.download_via_name("geneformer/geneformer-12L-30M/training_args.bin")
+    # downloader.download_via_name("geneformer/gene_median_dictionary.pkl")
+    # downloader.download_via_name("geneformer/token_dictionary.pkl")
+    # downloader.download_via_name("geneformer/geneformer-12L-30M/config.json")
+    # downloader.download_via_name("geneformer/geneformer-12L-30M/pytorch_model.bin")
+    # downloader.download_via_name("geneformer/geneformer-12L-30M/training_args.bin")
+    download_geneformer_models()
 
     downloader.download_via_name("hyena_dna/hyenadna-tiny-1k-seqlen.ckpt")
     downloader.download_via_name("hyena_dna/hyenadna-tiny-1k-seqlen-d256.ckpt")

--- a/ci/download_all.py
+++ b/ci/download_all.py
@@ -1,6 +1,7 @@
 from helical.services.downloader import Downloader
 from pathlib import Path
-
+import logging
+LOGGER = logging.getLogger(__name__)
 
 def download_geneformer_models():
     downloader = Downloader()
@@ -44,7 +45,7 @@ def download_geneformer_models():
             for file in model_files:
                 downloader.download_via_name(file)
     
-    print("All Geneformer models and files have been downloaded.")
+    LOGGER.info("All Geneformer models and files have been downloaded.")
 
 def main():
     downloader = Downloader()
@@ -60,11 +61,6 @@ def main():
     downloader.download_via_name("scgpt/scGPT_CP/vocab.json")
     downloader.download_via_name("scgpt/scGPT_CP/best_model.pt")
 
-    # downloader.download_via_name("geneformer/gene_median_dictionary.pkl")
-    # downloader.download_via_name("geneformer/token_dictionary.pkl")
-    # downloader.download_via_name("geneformer/geneformer-12L-30M/config.json")
-    # downloader.download_via_name("geneformer/geneformer-12L-30M/pytorch_model.bin")
-    # downloader.download_via_name("geneformer/geneformer-12L-30M/training_args.bin")
     download_geneformer_models()
 
     downloader.download_via_name("hyena_dna/hyenadna-tiny-1k-seqlen.ckpt")

--- a/ci/tests/test_geneformer/test_geneformer_model.py
+++ b/ci/tests/test_geneformer/test_geneformer_model.py
@@ -1,37 +1,47 @@
 import pytest
+import torch
 from helical.models.geneformer.model import Geneformer
+from helical.models.geneformer.geneformer_config import GeneformerConfig
+from helical.models.geneformer.geneformer_utils import get_embs, load_model
 from anndata import AnnData
-import numpy as np
-from helical.models.geneformer.geneformer_tokenizer import TranscriptomeTokenizer
-from pathlib import Path
-from helical.constants.paths import CACHE_DIR_HELICAL
 
 class TestGeneformerModel:
-    geneformer = Geneformer()
+    @pytest.fixture(params=["gf-12L-30M-i2048", "gf-12L-95M-i4096"])
+    def geneformer(self, request):
+        config = GeneformerConfig(model_name=request.param)
+        return Geneformer(config)
 
-    # Create a dummy AnnData object
-    data = AnnData()
-    data.var['gene_symbols'] = ['SAMD11', 'PLEKHN1', 'HES4']
-    data.obs["cell_type"] = ["CD4 T cells"]
-    data.X = [[1, 2, 5]]
-    tokenized_dataset = geneformer.process_data(data, gene_names='gene_symbols')
+    @pytest.fixture
+    def mock_data(self):
+        data = AnnData()
+        data.var['gene_symbols'] = ['SAMD11', 'PLEKHN1', 'HES4']
+        data.var['ensembl_id'] = ['ENSG00000187634', 'ENSG00000187583', 'ENSG00000188290']
+        data.obs["cell_type"] = ["CD4 T cells"]
+        data.X = [[1, 2, 5]]
+        return data
 
-    def test_process_data_mapping_to_ensemble_ids(self):
-        assert self.data.var['ensembl_id'][0] == 'ENSG00000187634'
+    def test_pass_invalid_model_name(self):
+        with pytest.raises(ValueError):
+            geneformer_config = GeneformerConfig(model_name='InvalidName')
+        
+
+    def test_process_data_mapping_to_ensemble_ids(self, geneformer, mock_data):
+        assert mock_data.var['ensembl_id'][0] == 'ENSG00000187634'
         # is the same as the above line but more verbose (linking the gene symbol to the ensembl id)
-        assert self.data.var[self.data.var['gene_symbols'] == 'SAMD11']['ensembl_id'].values[0] == 'ENSG00000187634'
-        assert self.data.var[self.data.var['gene_symbols'] == 'PLEKHN1']['ensembl_id'].values[0] == 'ENSG00000187583'
-        assert self.data.var[self.data.var['gene_symbols'] == 'HES4']['ensembl_id'].values[0] == 'ENSG00000188290'
+        assert mock_data.var[mock_data.var['gene_symbols'] == 'SAMD11']['ensembl_id'].values[0] == 'ENSG00000187634'
+        assert mock_data.var[mock_data.var['gene_symbols'] == 'PLEKHN1']['ensembl_id'].values[0] == 'ENSG00000187583'
+        assert mock_data.var[mock_data.var['gene_symbols'] == 'HES4']['ensembl_id'].values[0] == 'ENSG00000188290'
 
-    def test_process_data_padding_and_masking_ids(self):
+    def test_process_data_padding_and_masking_ids(self, geneformer, mock_data):
         # for this token mapping, the padding token is 0 and the mask token is 1
-        assert self.geneformer.gene_token_dict.get("<pad>") == 0
-        assert self.geneformer.gene_token_dict.get("<mask>") == 1
+        geneformer.process_data(mock_data, gene_names='gene_symbols')
+        assert geneformer.gene_token_dict.get("<pad>") == 0
+        assert geneformer.gene_token_dict.get("<mask>") == 1
 
-    def test_ensure_data_validity_raising_error_with_missing_ensembl_id_column(self):
-        del self.data.var['ensembl_id']
+    def test_ensure_data_validity_raising_error_with_missing_ensembl_id_column(self, geneformer, mock_data):
+        del mock_data.var['ensembl_id']
         with pytest.raises(KeyError):
-            self.geneformer.ensure_data_validity(self.data, "ensembl_id")
+            geneformer.ensure_data_validity(mock_data, "ensembl_id")
     
     @pytest.mark.parametrize("gene_symbols, raises_error",
                              [
@@ -40,9 +50,115 @@ class TestGeneformerModel:
                                 (['SAMD11', 'PLEKHN1', 'HES4'], False),
                              ]
     )
-    def test_ensembl_data_is_caught(self, gene_symbols, raises_error):
-        self.data.var['gene_symbols'] = gene_symbols
+    def test_ensembl_data_is_caught(self, geneformer, mock_data, gene_symbols, raises_error):
+        mock_data.var['gene_symbols'] = gene_symbols
         if raises_error:
             with pytest.raises(ValueError):
-                self.geneformer.process_data(self.data, "gene_symbols")
+                geneformer.process_data(mock_data, "gene_symbols")
+        else:
+            geneformer.process_data(mock_data, "gene_symbols")
+    def test_get_embs_cell_mode(self, geneformer, mock_data):
+        tokenized_dataset = geneformer.process_data(mock_data, gene_names='gene_symbols')
+        model = load_model("Pretrained", geneformer.files_config["model_files_dir"])
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        embs = get_embs(
+            model,
+            tokenized_dataset,
+            emb_mode="cell",
+            layer_to_quant=-1,
+            pad_token_id=geneformer.pad_token_id,
+            forward_batch_size=1,
+            token_gene_dict=geneformer.gene_token_dict,
+            device=device
+        )
+        assert embs.shape == (1, model.config.hidden_size)
+
+    def test_get_embs_cls_mode(self, geneformer, mock_data):
+        if not geneformer.config["special_token"]:
+            pytest.skip("This test is only for models with special tokens (v2)")
+        tokenized_dataset = geneformer.process_data(mock_data, gene_names='gene_symbols')
+        model = load_model("Pretrained", geneformer.files_config["model_files_dir"])
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        embs = get_embs(
+            model,
+            tokenized_dataset,
+            emb_mode="cls",
+            layer_to_quant=-1,
+            pad_token_id=geneformer.pad_token_id,
+            forward_batch_size=1,
+            gene_token_dict=geneformer.gene_token_dict,
+            device=device
+        )
+        assert embs.shape == (1, model.config.hidden_size)
+
+    def test_get_embs_gene_mode(self, geneformer, mock_data):
+        tokenized_dataset = geneformer.process_data(mock_data, gene_names='gene_symbols')
+        model = load_model("Pretrained", geneformer.files_config["model_files_dir"])
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        embs = get_embs(
+            model,
+            tokenized_dataset,
+            emb_mode="gene",
+            layer_to_quant=-1,
+            pad_token_id=geneformer.pad_token_id,
+            forward_batch_size=1,
+            gene_token_dict=geneformer.gene_token_dict,
+            device=device
+        )
+        assert embs.shape[0] == 1
+        assert embs.shape[2] == model.config.hidden_size
+
+    def test_get_embs_different_layer(self, geneformer, mock_data):
+        tokenized_dataset = geneformer.process_data(mock_data, gene_names='gene_symbols')
+        model = load_model("Pretrained", geneformer.files_config["model_files_dir"])
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        embs_last = get_embs(
+            model,
+            tokenized_dataset,
+            emb_mode="cell",
+            layer_to_quant=-1,
+            pad_token_id=geneformer.pad_token_id,
+            forward_batch_size=1,
+            gene_token_dict=geneformer.gene_token_dict,
+            device=device
+        )
+        embs_first = get_embs(
+            model,
+            tokenized_dataset,
+            emb_mode="cell",
+            layer_to_quant=0,
+            pad_token_id=geneformer.pad_token_id,
+            forward_batch_size=1,
+            gene_token_dict=geneformer.gene_token_dict,
+            device=device
+        )
+        assert not torch.allclose(embs_last, embs_first)
+
+    def test_get_embs_cell_mode(self, geneformer, mock_data):
+        tokenized_dataset = geneformer.process_data(mock_data, gene_names='gene_symbols')
+        model = load_model("Pretrained", geneformer.files_config["model_files_dir"])
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        embs = get_embs(
+            model,
+            tokenized_dataset,
+            emb_mode="cell",
+            layer_to_quant=-1,
+            pad_token_id=geneformer.pad_token_id,
+            forward_batch_size=1,
+            gene_token_dict=geneformer.gene_token_dict,
+            device=device
+        )
+        assert embs.shape == (1, model.config.hidden_size)
+
+    def test_cls_eos_tokens_presence(self, geneformer, mock_data):
+        geneformer.process_data(mock_data, gene_names='gene_symbols')
+        if geneformer.config["special_token"]:
+            assert "<cls>" in geneformer.tk.gene_token_dict
+            assert "<eos>" in geneformer.tk.gene_token_dict
+        else:
+            assert "<cls>" not in geneformer.tk.gene_token_dict
+            assert "<eos>" not in geneformer.tk.gene_token_dict
+
+    def test_model_input_size(self, geneformer):
+        assert geneformer.config["input_size"] == geneformer.configurer.model_map[geneformer.config["model_name"]]['input_size']
             

--- a/ci/tests/test_geneformer/test_geneformer_model.py
+++ b/ci/tests/test_geneformer/test_geneformer_model.py
@@ -8,7 +8,8 @@ from anndata import AnnData
 class TestGeneformerModel:
     @pytest.fixture(params=["gf-12L-30M-i2048", "gf-12L-95M-i4096"])
     def geneformer(self, request):
-        config = GeneformerConfig(model_name=request.param)
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        config = GeneformerConfig(model_name=request.param, device=self.device)
         return Geneformer(config)
 
     @pytest.fixture
@@ -59,7 +60,7 @@ class TestGeneformerModel:
             geneformer.process_data(mock_data, "gene_symbols")
     def test_get_embs_cell_mode(self, geneformer, mock_data):
         tokenized_dataset = geneformer.process_data(mock_data, gene_names='gene_symbols')
-        model = load_model("Pretrained", geneformer.files_config["model_files_dir"])
+        model = load_model("Pretrained", geneformer.files_config["model_files_dir"], self.device)
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         embs = get_embs(
             model,
@@ -77,7 +78,7 @@ class TestGeneformerModel:
         if not geneformer.config["special_token"]:
             pytest.skip("This test is only for models with special tokens (v2)")
         tokenized_dataset = geneformer.process_data(mock_data, gene_names='gene_symbols')
-        model = load_model("Pretrained", geneformer.files_config["model_files_dir"])
+        model = load_model("Pretrained", geneformer.files_config["model_files_dir"], self.device)
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         embs = get_embs(
             model,
@@ -93,7 +94,7 @@ class TestGeneformerModel:
 
     def test_get_embs_gene_mode(self, geneformer, mock_data):
         tokenized_dataset = geneformer.process_data(mock_data, gene_names='gene_symbols')
-        model = load_model("Pretrained", geneformer.files_config["model_files_dir"])
+        model = load_model("Pretrained", geneformer.files_config["model_files_dir"], self.device)
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         embs = get_embs(
             model,
@@ -110,7 +111,7 @@ class TestGeneformerModel:
 
     def test_get_embs_different_layer(self, geneformer, mock_data):
         tokenized_dataset = geneformer.process_data(mock_data, gene_names='gene_symbols')
-        model = load_model("Pretrained", geneformer.files_config["model_files_dir"])
+        model = load_model("Pretrained", geneformer.files_config["model_files_dir"], self.device)
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         embs_last = get_embs(
             model,
@@ -136,7 +137,7 @@ class TestGeneformerModel:
 
     def test_get_embs_cell_mode(self, geneformer, mock_data):
         tokenized_dataset = geneformer.process_data(mock_data, gene_names='gene_symbols')
-        model = load_model("Pretrained", geneformer.files_config["model_files_dir"])
+        model = load_model("Pretrained", geneformer.files_config["model_files_dir"], self.device)
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         embs = get_embs(
             model,

--- a/ci/tests/test_geneformer/test_geneformer_model.py
+++ b/ci/tests/test_geneformer/test_geneformer_model.py
@@ -58,6 +58,13 @@ class TestGeneformerModel:
                 geneformer.process_data(mock_data, "gene_symbols")
         else:
             geneformer.process_data(mock_data, "gene_symbols")
+
+    def test_cls_mode_with_v1_model_config(self, geneformer, mock_data):
+        if geneformer.config["special_token"]:
+            pytest.skip("This test is only for v1 models and should thus be only executed once.")
+        with pytest.raises(ValueError):
+            config = GeneformerConfig(model_name="gf-12L-30M-i2048", device="cpu", emb_mode='cls')
+
     def test_get_embs_cell_mode(self, geneformer, mock_data):
         tokenized_dataset = geneformer.process_data(mock_data, gene_names='gene_symbols')
         model = load_model("Pretrained", geneformer.files_config["model_files_dir"], self.device)

--- a/ci/tests/test_geneformer/test_geneformer_tokenizer.py
+++ b/ci/tests/test_geneformer/test_geneformer_tokenizer.py
@@ -1,151 +1,125 @@
 import pytest
-from helical.models.geneformer.geneformer_tokenizer import TranscriptomeTokenizer
-from anndata import AnnData
-from helical.constants.paths import CACHE_DIR_HELICAL
-from pathlib import Path
 import numpy as np
+from unittest import mock
+from anndata import AnnData
+from pathlib import Path
+import scipy.sparse as sp
+from helical.models.geneformer.geneformer_tokenizer import TranscriptomeTokenizer, sum_ensembl_ids
+from helical.constants.paths import CACHE_DIR_HELICAL
 
-
-class TestTranscriptomeTokenizer:
-    model_dir = Path(CACHE_DIR_HELICAL, "geneformer")
-    files_config = {
-        "gene_median_path": model_dir / "gene_median_dictionary.pkl",
-        "token_path": model_dir / "token_dictionary.pkl",
+class TestGeneformerTokenizer:
+    model_dir_v1 = Path(CACHE_DIR_HELICAL, "geneformer", "v1")
+    model_dir_v2 = Path(CACHE_DIR_HELICAL, "geneformer", "v2")
+    
+    files_config_v1 = {
+        "gene_median_path": model_dir_v1 / "gene_median_dictionary.pkl",
+        "token_path": model_dir_v1 / "token_dictionary.pkl",
+        "gene_mapping_path": model_dir_v1 / "ensembl_mapping_dict.pkl",
     }
-    tokenizer = TranscriptomeTokenizer(
-        gene_median_file=files_config["gene_median_path"],
-        token_dictionary_file=files_config["token_path"],
-    )
+    
+    files_config_v2 = {
+        "gene_median_path": model_dir_v2 / "gene_median_dictionary.pkl",
+        "token_path": model_dir_v2 / "token_dictionary.pkl",
+        "gene_mapping_path": model_dir_v2 / "ensembl_mapping_dict.pkl",
+    }
 
-    data_w_filter_pass = AnnData(np.array([[5], [5], [5], [5], [5], [5]]))
-    data_w_filter_pass.var["gene_symbols"] = ["a"]
-    data_w_filter_pass.obs["filter_pass"] = [1, 0, 1, 1, 0, 1]
-
-    data_without_filter_pass = AnnData(np.array([[5], [5], [5], [5], [5], [5]]))
-    data_without_filter_pass.var["gene_symbols"] = ["a"]
-
-    @pytest.mark.parametrize(
-        "data, expected_result",
-        [
-            #  the idea is to only tokenize where the filter is 1
-            (data_w_filter_pass, [0, 2, 3, 5]),
-            #  no 'filter_pass' in the obs of the anndata object, thus tokenize all the genes
-            (data_without_filter_pass, [0, 1, 2, 3, 4, 5]),
-        ],
-    )
-    def test_get_filter_pass_loc(self, data, expected_result):
-        """
-        Test that the _get_filter_pass_loc method of the GeneFormerTokenizer class correctly retrieves the indices of the 'filter_pass'
-        column in the AnnData object where the value is 1. The idea is to only tokenize where the filter is 1.
-        If there is no 'filter_pass' in the obs of the anndata object, the function should return all the indices, thus tokenize all the genes.
-        """
-        # Call the _get_filter_pass_loc method
-        filter_pass_loc = self.tokenizer._get_filter_pass_loc(data)
-
-        # Check the result
-        assert all(filter_pass_loc == expected_result)
-
-    @pytest.mark.parametrize(
-        "ensembl_ids, x_data_count, expected_token",
-        [
-            #  find the corresponding tokens for each ensemble id
-            (["ENSG00000187634"], [2], [16026]),
-            (["ENSG00000187583"], [2], [16012]),
-            (["ENSG00000188290"], [2], [16175]),
-            # x_data_count has an effect on the expected tokens: they are ranked in descending order of x_data_count
-            (
-                ["ENSG00000187634", "ENSG00000187583", "ENSG00000188290"],
-                [11, 99, 55],
-                [16012, 16175, 16026],
-            ),
-            (
-                ["ENSG00000187634", "ENSG00000187583", "ENSG00000188290"],
-                [99, 11, 55],
-                [16026, 16175, 16012],
-            ),
-            # TODO figure out how the count influences the tokenization as shown with the following tests:
-            (
-                ["ENSG00000187634", "ENSG00000187583", "ENSG00000188290"],
-                [999, 55, 11],
-                [16026, 16012, 16175],
-            ),
-            (
-                ["ENSG00000187634", "ENSG00000187583", "ENSG00000188290"],
-                [99, 55, 11],
-                [16012, 16026, 16175],
-            ),
-        ],
-    )
-    def test_tokenize_anndata(
-        self, ensembl_ids: list[str], x_data_count: list[int], expected_token: list[int]
-    ):
-        """
-        Test the `tokenize_anndata` method of the tokenizer.
-        The ensemble ids are correclty mapped to the right token. And the resulting tokenized_cells have the right order of this list of tokens.
-        Also test that the metadata is correctly extracted from the AnnData object using the custom_attr_name_dict variable.
-
-        Args:
-            ensembl_id (list[str]): The ensembl ids.
-            x_data_count: The count of x data.
-            expected_token: The expected token to compare against.
-        """
-        number_of_obs = 5
-        data = AnnData()
-        data.var["ensembl_id"] = ensembl_ids
-        data.obs["key_from_file"] = ["CD4 T cells"] * number_of_obs
-        data.X = [x_data_count] * number_of_obs
-        data.obs["total_counts"] = data.X.sum(axis=1)
-
-        self.tokenizer = TranscriptomeTokenizer(
-            custom_attr_name_dict={"key_from_file": "desired_key_in_dataset"},
-            gene_median_file=self.files_config["gene_median_path"],
-            token_dictionary_file=self.files_config["token_path"],
+    @pytest.fixture
+    def tokenizer_v1(self):
+        return TranscriptomeTokenizer(
+            gene_median_file=self.files_config_v1["gene_median_path"],
+            token_dictionary_file=self.files_config_v1["token_path"],
+            gene_mapping_file=self.files_config_v1["gene_mapping_path"],
+            model_input_size=2048,
+            special_token=False,
         )
 
-        tokenized_cells, cell_metadata = self.tokenizer.tokenize_anndata(data)
-        for tokenized_cell in tokenized_cells:
-            assert np.array_equal(tokenized_cell, expected_token)
-        assert len(tokenized_cells) == number_of_obs
-        assert cell_metadata == {"desired_key_in_dataset": ["CD4 T cells"] * number_of_obs}
-
-    @pytest.mark.parametrize(
-        "tokenized_cells, cell_metadata",
-        [
-            (
-                # simple example with the same length of tokenized cells
-                [[16026], [16026], [16026], [16026]],
-                {
-                    "cell_type": [
-                        "CD4 T cells",
-                        "CD4 T cells",
-                        "CD4 T cells",
-                        "CD4 T cells",
-                    ]
-                },
-            ),
-            (
-                # the length of the tokenized cells is different but is correctly taken into the dataset
-                [[1, 2, 3], [2, 2], [3]],
-                {
-                    "cell_type": [
-                        "a",
-                        "b",
-                        "c",
-                    ]
-                },
-            ),
-        ],
-    )
-    def test_create_dataset(self, tokenized_cells, cell_metadata):
-        """
-        Test the `create_dataset` method of the tokenizer. The tokenized dataset must contain "lenght" and "input_ids" columns.
-        If cell_metadata is provided, the dataset must contain the same information as the tokenized_cells variable.
-        """
-        # test the created dataset containing essentially the same information as the tokenized_cells variable
-        tokenized_dataset = self.tokenizer.create_dataset(
-            tokenized_cells, cell_metadata
+    @pytest.fixture
+    def tokenizer_v2(self):
+        return TranscriptomeTokenizer(
+            gene_median_file=self.files_config_v2["gene_median_path"],
+            token_dictionary_file=self.files_config_v2["token_path"],
+            gene_mapping_file=self.files_config_v2["gene_mapping_path"],
+            model_input_size=4096,
+            special_token=True,
         )
-        assert tokenized_dataset.shape == (len(tokenized_cells), 3)
-        assert tokenized_dataset["cell_type"] == cell_metadata["cell_type"]
-        assert tokenized_dataset["length"] == [len(x) for x in tokenized_cells]
-        assert tokenized_dataset["input_ids"] == tokenized_cells
+
+    def test_tokenizer_initialization(self, tokenizer_v1, tokenizer_v2):
+        assert tokenizer_v1.model_input_size == 2048
+        assert not tokenizer_v1.special_token
+        assert tokenizer_v2.model_input_size == 4096
+        assert tokenizer_v2.special_token
+
+    @pytest.mark.parametrize("collapse_gene_ids, expected_shape, expected_exception", [
+    (True, (2, 2), None),
+    (False, (2, 3), ValueError)
+    ])
+    def test_sum_ensembl_ids_h5ad(self, tmp_path, collapse_gene_ids, expected_shape, expected_exception):
+        # Create a test AnnData object
+        adata = AnnData(X=sp.csr_matrix([[1, 2, 3], [4, 5, 6]]))
+        adata.var['ensembl_id'] = ['ENSG1', 'ENSG2', 'ENSG2']
+        adata.obs['n_counts'] = [6, 15]
+        test_file = tmp_path / "test.h5ad"
+        adata.write_h5ad(test_file)
+
+        # Mock gene_mapping_dict and gene_token_dict
+        gene_mapping_dict = {'ENSG1': 'ENSG1', 'ENSG2': 'ENSG2'}
+        gene_token_dict = {'ENSG1': 1, 'ENSG2': 2}
+
+        if expected_exception:
+            with pytest.raises(expected_exception):
+                sum_ensembl_ids(test_file, collapse_gene_ids, gene_mapping_dict, gene_token_dict, file_format="h5ad")
+        else:
+            result = sum_ensembl_ids(test_file, collapse_gene_ids, gene_mapping_dict, gene_token_dict, file_format="h5ad")
+            assert isinstance(result, AnnData)
+            assert result.shape == expected_shape
+
+    def test_tokenize_anndata(self, tokenizer_v1, tmp_path):
+        # Create a test AnnData object
+        adata = AnnData(X=sp.csr_matrix([[1, 2, 3], [4, 5, 6]]))
+        adata.var['ensembl_id'] = ['ENSG1', 'ENSG2', 'ENSG3']
+        adata.obs['n_counts'] = [6, 15]
+        adata.obs['cell_type'] = ['A', 'B']
+        test_file = tmp_path / "test.h5ad"
+        adata.write_h5ad(test_file)
+
+        tokenizer_v1.custom_attr_name_dict = {'cell_type': 'cell_type'}
+        tokenized_cells, cell_metadata = tokenizer_v1.tokenize_anndata(test_file)
+
+        assert len(tokenized_cells) == 2
+        assert isinstance(tokenized_cells[0], np.ndarray)
+        assert cell_metadata == {'cell_type': ['A', 'B']}
+
+    @pytest.mark.parametrize("tokenizer, expected_max_length", [
+        ("tokenizer_v1", 2048),
+        ("tokenizer_v2", 4096)
+    ])
+    def test_create_dataset(self, request, tokenizer, expected_max_length):
+        tokenizer = request.getfixturevalue(tokenizer)
+        tokenized_cells = [np.array([1, 2, 3]), np.array([4, 5, 6])]
+        cell_metadata = None
+
+        dataset = tokenizer.create_dataset(tokenized_cells, cell_metadata)
+        assert len(dataset) == 2
+        assert 'input_ids' in dataset.features
+        assert 'length' in dataset.features
+        assert all(len(ids) <= expected_max_length for ids in dataset['input_ids'])
+
+        if tokenizer.special_token:
+            assert all(ids[0] == tokenizer.gene_token_dict['<cls>'] for ids in dataset['input_ids'])
+            assert all(ids[-1] == tokenizer.gene_token_dict['<eos>'] for ids in dataset['input_ids'])
+
+    def test_tokenize_data(self, tokenizer_v1, tmp_path):
+        # Create a test AnnData object
+        adata = AnnData(X=sp.csr_matrix([[1, 2, 3], [4, 5, 6]]))
+        adata.var['ensembl_id'] = ['ENSG1', 'ENSG2', 'ENSG3']
+        adata.obs['n_counts'] = [6, 15]
+        adata.obs['cell_type'] = ['A', 'B']
+        test_file = tmp_path / "test.h5ad"
+        adata.write_h5ad(test_file)
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        tokenizer_v1.tokenize_data(tmp_path, output_dir, "test_output", file_format="h5ad")
+
+        assert (output_dir / "test_output.dataset").exists()

--- a/ci/tests/test_scgpt/test_sampler.py
+++ b/ci/tests/test_scgpt/test_sampler.py
@@ -58,17 +58,21 @@ def test_subsets_batch_sampler() -> None:
     assert list(sampler) == [[0, 1, 2], [5, 6, 7]]
 
     # Test sampling with inter subset shuffle
-    sampler = SubsetsBatchSampler(
-        subsets,
-        batch_size=3,
-        intra_subset_shuffle=False,
-        inter_subset_shuffle=True,
-    )
-    sampled_idx = list(sampler)
-    assert len(sampled_idx) == 4
-    print(sampled_idx)
-    assert sampled_idx != [[0, 1, 2], [3, 4], [5, 6, 7], [8, 9]]
-    assert _check_reorder(sampled_idx, [[0, 1, 2], [3, 4], [5, 6, 7], [8, 9]])
+    for _ in range(5):  # Run 5 times to check for consistent behavior
+        sampler = SubsetsBatchSampler(
+            subsets,
+            batch_size=3,
+            intra_subset_shuffle=False,
+            inter_subset_shuffle=True,
+        )
+        sampled_idx = list(sampler)
+        assert len(sampled_idx) == 4
+        print(sampled_idx)
+        if sampled_idx != [[0, 1, 2], [3, 4], [5, 6, 7], [8, 9]]:
+            break
+    else:
+        assert False, "Inter-subset shuffle did not produce different orders in 5 attempts"
+        assert _check_reorder(sampled_idx, [[0, 1, 2], [3, 4], [5, 6, 7], [8, 9]])
 
     # Test sampling with intra subset shuffle
     sampler = SubsetsBatchSampler(

--- a/docs/model_cards/geneformer.md
+++ b/docs/model_cards/geneformer.md
@@ -6,6 +6,13 @@
 **Model Versions:** 1.0 and 2.0  
 **Model Description:** Geneformer is a context-aware, attention-based deep learning model pretrained on a large-scale corpus of single-cell transcriptomes. It is designed to enable context-specific predictions in settings with limited data in network biology. The model performs various downstream tasks such as gene network mapping, disease modeling, and therapeutic target identification.
 
+In version 2.0, Geneformer introduces a cancer-tuned model variant using domain-specific continual learning. This variant was developed to address the exclusion of malignant cells from the initial pretraining due to their propensity for gain-of-function mutations. The cancer-tuned model underwent additional training with ~14 million cells from cancer studies, including matched healthy controls, to provide contrasting context. This approach allows the model to better understand gene network rewiring in malignancy while maintaining its general knowledge of gene network dynamics.
+
+When to use each model:
+- Base pretrained model: Use for general transcriptomic analysis tasks and non-cancer-specific applications.
+- Cancer-tuned model: Use for cancer-specific analyses, tumor microenvironment studies, and predicting factors that could shift cells to tumor-restricting or immune-activating states.
+
+
 ## Model Versions
 
 Geneformer has two main versions:
@@ -29,6 +36,33 @@ Key improvements in v2.0:
 - Multi-task learning for context-specific representations of gene network dynamics (use of <cls> and <eos> embedding tokens to that effect)
 - Improved zero-shot predictions in diverse downstream tasks
 - Cancer-specific tuning for tumor microenvironment analysis
+
+## Available Models for each Version
+
+### Version 1.0 (30M dataset)
+- **gf-6L-30M-i2048**
+  - 6 layers
+  - 2048 input size
+  - Trained on ~30 million cells
+- **gf-12L-30M-i2048**
+  - 12 layers
+  - 2048 input size
+  - Trained on ~30 million cells
+
+### Version 2.0 (95M dataset)
+- **gf-12L-95M-i4096**
+  - 12 layers
+  - 4096 input size
+  - Trained on ~95 million cells
+- **gf-20L-95M-i4096**
+  - 20 layers
+  - 4096 input size
+  - Trained on ~95 million cells
+- **gf-12L-95M-i4096-CLcancer**
+  - 12 layers
+  - 4096 input size
+  - Initially trained on ~95 million cells
+  - Further tuned on ~14 million cancer cells
 
 ## Model Developers
 
@@ -143,11 +177,17 @@ geneformer_v2 = Geneformer(model_config=model_config_v2)
 model_config_v2_cancer = GeneformerConfig(model_name="gf-12L-95M-i4096-CLcancer", batch_size=10)
 geneformer_v2_cancer = Geneformer(model_config=model_config_v2_cancer)
 
-# Example usage (same for all versions)
-ann_data = ad.read_h5ad("dataset.h5ad")
+# Example usage for base pretrained model (for general transcriptomic analysis, v1 and v2)
+ann_data = ad.read_h5ad("general_dataset.h5ad")
 dataset = geneformer_v2.process_data(ann_data)
 embeddings = geneformer_v2.get_embeddings(dataset)
-print(embeddings.shape)
+print("Base model embeddings shape:", embeddings.shape)
+
+# Example usage for cancer-tuned model (for cancer-specific analysis)
+cancer_ann_data = ad.read_h5ad("cancer_dataset.h5ad")
+cancer_dataset = geneformer_v2_cancer.process_data(cancer_ann_data)
+cancer_embeddings = geneformer_v2_cancer.get_embeddings(cancer_dataset)
+print("Cancer-tuned model embeddings shape:", cancer_embeddings.shape)
 
 
 ```

--- a/docs/model_cards/geneformer.md
+++ b/docs/model_cards/geneformer.md
@@ -2,9 +2,33 @@
 
 ## Model Details
 
-**Model Name:** Geneformer  \
-**Model Version:** 1.0  \
-**Model Description:** Geneformer is a context-aware, attention-based deep learning model pretrained on a large-scale corpus of approximately 30 million single-cell transcriptomes. It is designed to enable context-specific predictions in settings with limited data in network biology. The model performs various tasks such as gene network mapping, disease modeling, and therapeutic target identification. 
+**Model Name:** Geneformer  
+**Model Versions:** 1.0 and 2.0  
+**Model Description:** Geneformer is a context-aware, attention-based deep learning model pretrained on a large-scale corpus of single-cell transcriptomes. It is designed to enable context-specific predictions in settings with limited data in network biology. The model performs various downstream tasks such as gene network mapping, disease modeling, and therapeutic target identification.
+
+## Model Versions
+
+Geneformer has two main versions:
+
+**Version 1.0:**
+- Pretrained on approximately 30 million single-cell transcriptomes
+- Input size of 2048 genes per cell
+- Focused on single-task learning
+
+**Version 2.0:**
+- Pretrained on Genecorpus-103M, comprising ~103 million human single-cell transcriptomes
+- Initial self-supervised pretraining with ~95 million cells, excluding cells with high mutational burdens
+- Expanded input/context size of 4096 genes per cell
+- Employs multi-task learning to jointly learn cell types, tissues, disease states, and developmental stages
+- Includes a cancer-tuned model variant using domain-specific continual learning
+- Supports model quantization for resource-efficient fine-tuning and inference
+
+Key improvements in v2.0:
+- Larger and more diverse pretraining corpus
+- Increased model parameters and expanded input size
+- Multi-task learning for context-specific representations of gene network dynamics (use of <cls> and <eos> embedding tokens to that effect)
+- Improved zero-shot predictions in diverse downstream tasks
+- Cancer-specific tuning for tumor microenvironment analysis
 
 ## Model Developers
 
@@ -42,12 +66,15 @@
 - Publicly available single-cell transcriptomic datasets (e.g., NCBI Gene Expression Omnibus, Human Cell Atlas, EMBL-EBI Single Cell Expression Atlas)
 
 **Data Volume:**  
-- 29.9 million single-cell transcriptomes across a wide range of tissues
+- Version 1.0: 29.9 million single-cell transcriptomes across a wide range of tissues
+- Version 2.0: ~103 million human single-cell transcriptomes (Genecorpus-103M), including:
+  - ~95 million cells for initial self-supervised pretraining
+  - ~14 million cells from cancer studies for domain-specific continual learning
 
 **Preprocessing:**  
 - Exclusion of cells with high mutational burdens
 - Metrics established for scalable filtering to exclude possible doublets and/or damaged cells
-- Rank value encoding of transcriptomes where genes are ranked by scaled expression within each cell.
+- Rank value encoding of transcriptomes where genes are ranked by scaled expression within each cell
 
 ## Model Performance
 
@@ -104,13 +131,24 @@
 from helical.models.geneformer.model import Geneformer,GeneformerConfig
 import anndata as ad
 
-model_config = GeneformerConfig(batch_size = 10)
-geneformer = Geneformer(model_config = model_config)
-ann_data = ad.read_h5ad("dataset.h5ad")
-dataset = geneformer.process_data(ann_data)
-embeddings = geneformer.get_embeddings(dataset)
+# For Version 1.0
+model_config_v1 = GeneformerConfig(model_name="gf-12L-30M-i2048", batch_size=10)
+geneformer_v1 = Geneformer(model_config=model_config_v1)
 
+#For Version 2.0
+model_config_v2 = GeneformerConfig(model_name="gf-12L-95M-i4096", batch_size=10)
+geneformer_v2 = Geneformer(model_config=model_config_v2)
+
+# For Version 2.0 (Cancer-tuned)
+model_config_v2_cancer = GeneformerConfig(model_name="gf-12L-95M-i4096-CLcancer", batch_size=10)
+geneformer_v2_cancer = Geneformer(model_config=model_config_v2_cancer)
+
+# Example usage (same for all versions)
+ann_data = ad.read_h5ad("dataset.h5ad")
+dataset = geneformer_v2.process_data(ann_data)
+embeddings = geneformer_v2.get_embeddings(dataset)
 print(embeddings.shape)
+
 
 ```
 

--- a/docs/model_cards/geneformer.md
+++ b/docs/model_cards/geneformer.md
@@ -8,6 +8,9 @@
 
 In version 2.0, Geneformer introduces a cancer-tuned model variant using domain-specific continual learning. This variant was developed to address the exclusion of malignant cells from the initial pretraining due to their propensity for gain-of-function mutations. The cancer-tuned model underwent additional training with ~14 million cells from cancer studies, including matched healthy controls, to provide contrasting context. This approach allows the model to better understand gene network rewiring in malignancy while maintaining its general knowledge of gene network dynamics.
 
+The first version of the model is published in this <a href="https://www.nature.com/articles/s41586-023-06139-9.epdf?sharing_token=u_5LUGVkd3A8zR-f73lU59RgN0jAjWel9jnR3ZoTv0N2UB4yyXENUK50s6uqjXH69sDxh4Z3J4plYCKlVME-W2WSuRiS96vx6t5ex2-krVDS46JkoVvAvJyWtYXIyj74pDWn_DutZq1oAlDaxfvBpUfSKDdBPJ8SKlTId8uT47M%3D">Nature Paper</a>. 
+The second version of the model is available at <a href="https://pubmed.ncbi.nlm.nih.gov/39229018/">NIH</a>.
+
 When to use each model:
 - Base pretrained model: Use for general transcriptomic analysis tasks and non-cancer-specific applications.
 - Cancer-tuned model: Use for cancer-specific analyses, tumor microenvironment studies, and predicting factors that could shift cells to tumor-restricting or immune-activating states.
@@ -98,6 +101,8 @@ Key improvements in v2.0:
 
 **Data Sources:**  
 - Publicly available single-cell transcriptomic datasets (e.g., NCBI Gene Expression Omnibus, Human Cell Atlas, EMBL-EBI Single Cell Expression Atlas)
+- GeneCorpus-30M is available on the [Hugging Face Dataset Hub](https://huggingface.co/datasets/ctheodoris/Genecorpus-30M)
+- Genecorpus-103M will be available on Hugging Face Dataset Hub. (coming soon)
 
 **Data Volume:**  
 - Version 1.0: 29.9 million single-cell transcriptomes across a wide range of tissues
@@ -165,17 +170,14 @@ Key improvements in v2.0:
 from helical.models.geneformer.model import Geneformer,GeneformerConfig
 import anndata as ad
 
-# For Version 1.0
-model_config_v1 = GeneformerConfig(model_name="gf-12L-30M-i2048", batch_size=10)
-geneformer_v1 = Geneformer(model_config=model_config_v1)
+# Example configuration
+model_config = GeneformerConfig(model_name="gf-12L-95M-i4096", batch_size=10)
+geneformer = Geneformer(model_config=model_config)
 
-#For Version 2.0
-model_config_v2 = GeneformerConfig(model_name="gf-12L-95M-i4096", batch_size=10)
-geneformer_v2 = Geneformer(model_config=model_config_v2)
-
-# For Version 2.0 (Cancer-tuned)
-model_config_v2_cancer = GeneformerConfig(model_name="gf-12L-95M-i4096-CLcancer", batch_size=10)
-geneformer_v2_cancer = Geneformer(model_config=model_config_v2_cancer)
+# You can use other model names in the config, such as:
+# "gf-12L-30M-i2048" (Version 1.0)
+# "gf-12L-95M-i4096-CLcancer" (Version 2.0, Cancer-tuned)
+# "gf-20L-95M-i4096" (Version 2.0, 20-layer model)
 
 # Example usage for base pretrained model (for general transcriptomic analysis, v1 and v2)
 ann_data = ad.read_h5ad("general_dataset.h5ad")
@@ -200,6 +202,12 @@ christina.theodoris@gladstone.ucsf.edu
 
 Theodoris, C. V., Xiao, L., Chopra, A., Chaffin, M. D., Al Sayed, Z. R., Hill, M. C., Mantineo, H., Brydon, E. M., Zeng, Z., Liu, X. S., & Ellinor, P. T. (2023). Transfer learning enables predictions in network biology. Nature, 618, 616-624. https://doi.org/10.1038/s41586-023-06139-9
 
+ 
+H Chen*, M S Venkatesh*, J Gomez Ortega, S V Mahesh, T Nandi, R Madduri, K Pelka†, C V Theodoris†#. Quantized multi-task learning for context-specific representations of gene network dynamics. bioRxiv, 19 Aug 2024. (*co-first authors, †co-senior authors, #corresponding author). https://doi.org/10.1101/2024.08.16.608180
+
+
 ## Author contributions 
 
 C.V.T. conceived of the work, developed Geneformer, assembled Genecorpus-30M and designed and performed computational analyses. L.X., A.C., Z.R.A.S., M.C.H., H.M. and E.M.B. performed experimental validation in engineered cardiac microtissues. M.D.C. performed preprocessing, cell annotation and differential expression analysis of the cardiomyopathy dataset. Z.Z. provided data from the TISCH database for inclusion in Genecorpus-30M. X.S.L. and P.T.E. designed analyses and supervised the work. C.V.T., X.S.L. and P.T.E. 
+
+HC and MSV developed the models and designed/performed computational analyses. HC assembled the pretraining corpuses and developed the continual learning method. MSV developed the multi-task learning method and quantization strategy. JGO contributed to model pretraining and corpus assembly. 

--- a/examples/run_models/configs/geneformer_config.yaml
+++ b/examples/run_models/configs/geneformer_config.yaml
@@ -1,4 +1,4 @@
-model_name: "gf-12L-95M-i4096"
+model_name: "gf-12L-30M-i4096"
 batch_size: 24
 emb_layer: -1
 emb_mode: "cell"

--- a/examples/run_models/configs/geneformer_config.yaml
+++ b/examples/run_models/configs/geneformer_config.yaml
@@ -1,4 +1,4 @@
-model_name: "gf-12L-30M-i4096"
+model_name: "gf-12L-30M-i2048"
 batch_size: 24
 emb_layer: -1
 emb_mode: "cell"

--- a/examples/run_models/configs/geneformer_config.yaml
+++ b/examples/run_models/configs/geneformer_config.yaml
@@ -1,4 +1,4 @@
-model_name: "gf-12L-30M-i2048"
+model_name: "gf-12L-95M-i4096"
 batch_size: 24
 emb_layer: -1
 emb_mode: "cell"

--- a/examples/run_models/configs/geneformer_config_v2.yaml
+++ b/examples/run_models/configs/geneformer_config_v2.yaml
@@ -1,6 +1,0 @@
-model_name: "gf-12L-95M-i4096"
-batch_size: 24
-emb_layer: -1
-emb_mode: "cell"
-device: "cpu"
-accelerator: False

--- a/examples/run_models/configs/geneformer_config_v2.yaml
+++ b/examples/run_models/configs/geneformer_config_v2.yaml
@@ -1,4 +1,4 @@
-model_name: "gf-12L-30M-i2048"
+model_name: "gf-12L-95M-i4096"
 batch_size: 24
 emb_layer: -1
 emb_mode: "cell"

--- a/examples/run_models/run_geneformer.py
+++ b/examples/run_models/run_geneformer.py
@@ -3,6 +3,7 @@ import anndata as ad
 import hydra
 from omegaconf import DictConfig
 
+
 @hydra.main(version_base=None, config_path="configs", config_name="geneformer_config")
 def run(cfg: DictConfig):
     geneformer_config = GeneformerConfig(**cfg)
@@ -13,6 +14,7 @@ def run(cfg: DictConfig):
     embeddings = geneformer.get_embeddings(dataset)
 
     print(embeddings.shape)
+
 
 
 if __name__ == "__main__":

--- a/helical/models/geneformer/geneformer_config.py
+++ b/helical/models/geneformer/geneformer_config.py
@@ -32,7 +32,7 @@ class GeneformerConfig():
             model_name: Literal["gf-6L-30M-i2048", "gf-12L-30M-i2048", "gf-12L-95M-i4096", "gf-20L-95M-i4096", "gf-12L-95M-i4096-CLcancer"] = "gf-12L-30M-i2048",
             batch_size: int = 24,
             emb_layer: int = -1,
-            emb_mode: str = "cell",
+            emb_mode: Literal["cls", "cell", "gene"] = "cell",
             device: Literal["cpu", "cuda"] = "cpu",
             accelerator: Optional[bool] = False
             ):
@@ -65,6 +65,9 @@ class GeneformerConfig():
             raise ValueError(f"Model name {model_name} not found in available models: {self.model_map.keys()}")
         
         model_version = 'v2' if "95M" in model_name else 'v1'
+
+        if model_version == 'v1' and emb_mode=='cls':
+            raise ValueError(f"Verson 1 Geneformer models do not support the CLS embedding mode")
         
         self.list_of_files_to_download = [
             f"geneformer/{model_version}/gene_median_dictionary.pkl",

--- a/helical/models/geneformer/geneformer_config.py
+++ b/helical/models/geneformer/geneformer_config.py
@@ -8,7 +8,7 @@ class GeneformerConfig():
     
     Parameters
     ----------
-    model_name : Literal["gf-6L-30M-i2048", "gf-12L-30M-i2048", "gf-12L-95M-i4096", "gf-20L-95M-i4096", "gf-12L-95M-i4096-CLcancer"], optional, default = "gf-12L-95M-i4096"
+    model_name : Literal["gf-6L-30M-i2048", "gf-12L-30M-i2048", "gf-12L-95M-i4096", "gf-20L-95M-i4096", "gf-12L-95M-i4096-CLcancer"], optional, default = "gf-12L-30M-i4096"
         The name of the model.
     batch_size : int, optional, default = 24
         The batch size
@@ -29,7 +29,7 @@ class GeneformerConfig():
     """
     def __init__(
             self, 
-            model_name: Literal["gf-6L-30M-i2048", "gf-12L-30M-i2048", "gf-12L-95M-i4096", "gf-20L-95M-i4096", "gf-12L-95M-i4096-CLcancer"] = "gf-12L-95M-i4096",
+            model_name: Literal["gf-6L-30M-i2048", "gf-12L-30M-i2048", "gf-12L-95M-i4096", "gf-20L-95M-i4096", "gf-12L-95M-i4096-CLcancer"] = "gf-12L-30M-i4096",
             batch_size: int = 24,
             emb_layer: int = -1,
             emb_mode: str = "cell",

--- a/helical/models/geneformer/geneformer_config.py
+++ b/helical/models/geneformer/geneformer_config.py
@@ -8,6 +8,8 @@ class GeneformerConfig():
     
     Parameters
     ----------
+    model_name : Literal["gf-6L-30M-i2048", "gf-12L-30M-i2048", "gf-12L-95M-i4096", "gf-20L-95M-i4096", "gf-12L-95M-i4096-CLcancer"], optional, default = "gf-12L-95M-i4096"
+        The name of the model.
     batch_size : int, optional, default = 24
         The batch size
     emb_layer : int, optional, default = -1
@@ -27,6 +29,7 @@ class GeneformerConfig():
     """
     def __init__(
             self, 
+            model_name: Literal["gf-6L-30M-i2048", "gf-12L-30M-i2048", "gf-12L-95M-i4096", "gf-20L-95M-i4096", "gf-12L-95M-i4096-CLcancer"] = "gf-12L-95M-i4096",
             batch_size: int = 24,
             emb_layer: int = -1,
             emb_mode: str = "cell",
@@ -34,22 +37,69 @@ class GeneformerConfig():
             accelerator: Optional[bool] = False
             ):
         
-        model_name = "geneformer-12L-30M"
+        # model specific parameters
+        self.model_map = {
+            "gf-12L-95M-i4096": {
+                'input_size': 4096,
+                'special_token': True,
+            },
+            "gf-12L-95M-i4096-CLcancer": {
+                'input_size': 4096,
+                'special_token': True,
+            },
+            "gf-20L-95M-i4096": {
+                'input_size': 4096,
+                'special_token': True,
+            },
+            "gf-12L-30M-i2048": {
+                'input_size': 2048,
+                'special_token': False,
+            },
+            "gf-6L-30M-i2048": {
+                'input_size': 2048,
+                'special_token': False,
+            },
+
+        }
+        if model_name not in self.model_map:
+            raise ValueError(f"Model name {model_name} not found in available models: {self.model_map.keys()}")
+        
+        model_version = 'v2' if "95M" in model_name else 'v1'
         
         self.list_of_files_to_download = [
-            "geneformer/gene_median_dictionary.pkl",
-            "geneformer/token_dictionary.pkl",
-            f"geneformer/{model_name}/config.json",
-            f"geneformer/{model_name}/pytorch_model.bin",
-            f"geneformer/{model_name}/training_args.bin",
-            ]
+            f"geneformer/{model_version}/gene_median_dictionary.pkl",
+            f"geneformer/{model_version}/token_dictionary.pkl",
+            f"geneformer/{model_version}/ensembl_mapping_dict.pkl",
+            f"geneformer/{model_version}/{model_name}/config.json",
+            f"geneformer/{model_version}/{model_name}/training_args.bin",
+        ]
+
+        # Add model weight files to download based on the model version (v1 or v2)
+        if model_version == 'v2':
+            self.list_of_files_to_download.append(f"geneformer/{model_version}/{model_name}/generation_config.json")
+            self.list_of_files_to_download.append(f"geneformer/{model_version}/{model_name}/model.safetensors")
+        else:
+            self.list_of_files_to_download.append(f"geneformer/{model_version}/{model_name}/pytorch_model.bin")
 
         self.model_dir = Path(CACHE_DIR_HELICAL, 'geneformer')
-        self.model_name = model_name
-        self.batch_size = batch_size
-        self.emb_layer = emb_layer
-        self.emb_mode = emb_mode
-        self.device = device
-        self.accelerator = accelerator
+
+        self.files_config = {
+            "model_files_dir": Path(CACHE_DIR_HELICAL, 'geneformer', model_version, model_name),
+            "gene_median_path": self.model_dir / model_version / "gene_median_dictionary.pkl",
+            "token_path": self.model_dir / model_version / "token_dictionary.pkl",
+            "ensembl_dict_path": self.model_dir / model_version / "ensembl_mapping_dict.pkl",
+        }
+
+        self.config = {
+            "model_name": model_name,
+            "batch_size": batch_size,
+            "emb_layer": emb_layer,
+            "emb_mode": emb_mode,
+            "device": device,
+            "accelerator": accelerator,
+            "input_size": self.model_map[model_name]['input_size'],
+            "special_token": self.model_map[model_name]['special_token'],
+        }
+    
 
 

--- a/helical/models/geneformer/geneformer_config.py
+++ b/helical/models/geneformer/geneformer_config.py
@@ -8,7 +8,7 @@ class GeneformerConfig():
     
     Parameters
     ----------
-    model_name : Literal["gf-6L-30M-i2048", "gf-12L-30M-i2048", "gf-12L-95M-i4096", "gf-20L-95M-i4096", "gf-12L-95M-i4096-CLcancer"], optional, default = "gf-12L-30M-i4096"
+    model_name : Literal["gf-6L-30M-i2048", "gf-12L-30M-i2048", "gf-12L-95M-i4096", "gf-20L-95M-i4096", "gf-12L-95M-i4096-CLcancer"], optional, default = "gf-12L-30M-i2048"
         The name of the model.
     batch_size : int, optional, default = 24
         The batch size
@@ -29,7 +29,7 @@ class GeneformerConfig():
     """
     def __init__(
             self, 
-            model_name: Literal["gf-6L-30M-i2048", "gf-12L-30M-i2048", "gf-12L-95M-i4096", "gf-20L-95M-i4096", "gf-12L-95M-i4096-CLcancer"] = "gf-12L-30M-i4096",
+            model_name: Literal["gf-6L-30M-i2048", "gf-12L-30M-i2048", "gf-12L-95M-i4096", "gf-20L-95M-i4096", "gf-12L-95M-i4096-CLcancer"] = "gf-12L-30M-i2048",
             batch_size: int = 24,
             emb_layer: int = -1,
             emb_mode: str = "cell",

--- a/helical/models/geneformer/geneformer_tokenizer.py
+++ b/helical/models/geneformer/geneformer_tokenizer.py
@@ -37,29 +37,34 @@ Geneformer tokenizer.
 
 | If one's data is in other formats besides .loom or .h5ad, one can use the relevant tools (such as Anndata tools) to convert the file to a .loom or .h5ad format prior to running the transcriptome tokenizer.
 
+| OF NOTE: Take care that the correct token dictionary and gene median file is used for the correct model. 
+
+| OF NOTE: For 95M model series, special_token should be True and model_input_size should be 4096. For 30M model series, special_token should be False and model_input_size should be 2048.
+
 """
 
 from __future__ import annotations
 
+import os
 import logging
 import pickle
 import warnings
 from pathlib import Path
 from typing import Literal
+from collections import Counter
 
-import anndata as ad
 import loompy as lp
 import numpy as np
 import scipy.sparse as sp
 from datasets import Dataset
 from anndata import AnnData
 from numpy import ndarray
+import pandas as pd
+from tqdm import tqdm
+import scanpy as sc
 
 warnings.filterwarnings("ignore", message=".*The 'nopython' keyword.*")
 LOGGER = logging.getLogger(__name__)
-
-GENE_MEDIAN_FILE = Path(__file__).parent / "gene_median_dictionary.pkl"
-TOKEN_DICTIONARY_FILE = Path(__file__).parent / "token_dictionary.pkl"
 
 
 def rank_genes(gene_vector, gene_tokens):
@@ -82,34 +87,244 @@ def tokenize_cell(gene_vector, gene_tokens):
     return rank_genes(gene_vector[nonzero_mask], gene_tokens[nonzero_mask])
 
 
+def sum_ensembl_ids(
+    data_directory,
+    collapse_gene_ids,
+    gene_mapping_dict,
+    gene_token_dict,
+    file_format="loom",
+    chunk_size=512,
+):
+    """
+    Process genomic data by mapping and potentially collapsing Ensembl IDs.
+
+    This function handles both Loom and H5AD file formats. It maps Ensembl IDs
+    using a provided dictionary and, if necessary, collapses and sums counts for
+    duplicate IDs. If no duplicate IDs are found and collapsing is not necessary, the function
+      returns the original data without modifications.
+    """
+    
+    if file_format == "loom":
+        """
+        Map Ensembl IDs from gene mapping dictionary. If duplicate Ensembl IDs are found, sum counts together.
+        """
+        with lp.connect(data_directory) as data:
+            assert (
+                "ensembl_id" in data.ra.keys()
+            ), "'ensembl_id' column missing from data.ra.keys()"
+            gene_ids_in_dict = [
+                gene for gene in data.ra.ensembl_id if gene in gene_token_dict.keys()
+            ]
+            if len(gene_ids_in_dict) == len(set(gene_ids_in_dict)):
+                token_genes_unique = True
+            else:
+                token_genes_unique = False
+            if collapse_gene_ids is False:
+                if token_genes_unique:
+                    return data_directory
+                else:
+                    raise ValueError("Error: data Ensembl IDs non-unique.")
+
+            gene_ids_collapsed = [
+                gene_mapping_dict.get(str(gene_id).upper()) for gene_id in data.ra.ensembl_id
+            ]
+            gene_ids_collapsed_in_dict = [
+                gene for gene in gene_ids_collapsed if gene in gene_token_dict.keys()
+            ]
+
+            if (
+                len(set(gene_ids_collapsed_in_dict)) == len(set(gene_ids_in_dict))
+            ) and token_genes_unique:
+                return data_directory
+            else:
+                dedup_filename = data_directory.with_name(
+                    data_directory.stem + "__dedup.loom"
+                )
+                data.ra["gene_ids_collapsed"] = gene_ids_collapsed
+                dup_genes = [
+                    idx
+                    for idx, count in Counter(data.ra["gene_ids_collapsed"]).items()
+                    if count > 1
+                ]
+                num_chunks = int(np.ceil(data.shape[1] / chunk_size))
+                first_chunk = True
+                for _, _, view in tqdm(
+                    data.scan(axis=1, batch_size=chunk_size), total=num_chunks
+                ):
+
+                    def process_chunk(view, duplic_genes):
+                        data_count_view = pd.DataFrame(
+                            view, index=data.ra["gene_ids_collapsed"]
+                        )
+                        unique_data_df = data_count_view.loc[
+                            ~data_count_view.index.isin(duplic_genes)
+                        ]
+                        dup_data_df = data_count_view.loc[
+                            data_count_view.index.isin(
+                                [i for i in duplic_genes if "None" not in i]
+                            )
+                        ]
+                        summed_data = dup_data_df.groupby(dup_data_df.index).sum()
+                        if not summed_data.index.is_unique:
+                            raise ValueError(
+                                "Error: Ensembl IDs in summed data frame non-unique."
+                            )
+                        data_count_view = pd.concat(
+                            [unique_data_df, summed_data], axis=0
+                        )
+                        if not data_count_view.index.is_unique:
+                            raise ValueError(
+                                "Error: Ensembl IDs in final data frame non-unique."
+                            )
+                        return data_count_view
+
+                    processed_chunk = process_chunk(view[:, :], dup_genes)
+                    processed_array = processed_chunk.to_numpy()
+                    new_row_attrs = {"ensembl_id": processed_chunk.index.to_numpy()}
+
+                    if "n_counts" not in view.ca.keys():
+                        total_count_view = np.sum(view[:, :], axis=0).astype(int)
+                        view.ca["n_counts"] = total_count_view
+
+                    if first_chunk:  # Create the Loom file with the first chunk
+                        lp.create(
+                            f"{dedup_filename}",
+                            processed_array,
+                            row_attrs=new_row_attrs,
+                            col_attrs=view.ca,
+                        )
+                        first_chunk = False
+                    else:  # Append subsequent chunks
+                        with lp.connect(dedup_filename, mode="r+") as dsout:
+                            dsout.add_columns(processed_array, col_attrs=view.ca)
+                return dedup_filename
+
+    elif file_format == "h5ad":
+        """
+        Map Ensembl IDs from gene mapping dictionary. If duplicate Ensembl IDs are found, sum counts together.
+        Returns adata object with deduplicated Ensembl IDs.
+        """
+
+        data = sc.read_h5ad(str(data_directory))
+
+        assert (
+            "ensembl_id" in data.var.columns
+        ), "'ensembl_id' column missing from data.var"
+        gene_ids_in_dict = [
+            gene for gene in data.var.ensembl_id if gene in gene_token_dict.keys()
+        ]
+        if len(gene_ids_in_dict) == len(set(gene_ids_in_dict)):
+            token_genes_unique = True
+        else:
+            token_genes_unique = False
+        if collapse_gene_ids is False:
+            if token_genes_unique:
+                return data
+            else:
+                raise ValueError("Error: data Ensembl IDs non-unique.")
+
+        gene_ids_collapsed = [
+            gene_mapping_dict.get(str(gene_id).upper()) for gene_id in data.var.ensembl_id
+        ]
+        gene_ids_collapsed_in_dict = [
+            gene for gene in gene_ids_collapsed if gene in gene_token_dict.keys()
+        ]
+        if (
+            len(set(gene_ids_collapsed_in_dict)) == len(set(gene_ids_in_dict))
+        ) and token_genes_unique:
+            return data
+
+        else:
+            data.var["gene_ids_collapsed"] = gene_ids_collapsed
+            data.var_names = gene_ids_collapsed
+            data = data[:, ~data.var.index.isna()]
+            dup_genes = [
+                idx for idx, count in Counter(data.var_names).items() if count > 1
+            ]
+
+            num_chunks = int(np.ceil(data.shape[0] / chunk_size))
+
+            processed_genes = []
+            for i in tqdm(range(num_chunks)):
+                start_idx = i * chunk_size
+                end_idx = min((i + 1) * chunk_size, data.shape[0])
+                data_chunk = data[start_idx:end_idx, :]
+
+                processed_chunks = []
+                for dup_gene in dup_genes:
+                    data_dup_gene = data_chunk[:, data_chunk.var_names == dup_gene]
+                    df = pd.DataFrame.sparse.from_spmatrix(
+                        data_dup_gene.X,
+                        index=data_dup_gene.obs_names,
+                        columns=data_dup_gene.var_names,
+                    )
+                    df_sum = pd.DataFrame(df.sum(axis=1))
+                    df_sum.columns = [dup_gene]
+                    df_sum.index = data_dup_gene.obs.index
+                    processed_chunks.append(df_sum)
+
+                processed_chunks = pd.concat(processed_chunks, axis=1)
+                processed_genes.append(processed_chunks)
+            processed_genes = pd.concat(processed_genes, axis=0)
+            var_df = pd.DataFrame({"gene_ids_collapsed": processed_genes.columns})
+            var_df.index = processed_genes.columns
+            processed_genes = sc.AnnData(X=processed_genes, obs=data.obs, var=var_df)
+
+            data_dedup = data[:, ~data.var.index.isin(dup_genes)]  # Deduplicated data
+            data_dedup = sc.concat([data_dedup, processed_genes], axis=1)
+            data_dedup.obs = data.obs
+            data_dedup.var = data_dedup.var.rename(
+                columns={"gene_ids_collapsed": "ensembl_id"}
+            )
+            return data_dedup
+
+
+DEFAULT_GENE_MEDIAN_FILE = Path(__file__).parent / "v1" / "gene_median_dictionary.pkl"
+DEFAULT_TOKEN_DICTIONARY_FILE = Path(__file__).parent / "v1" / "token_dictionary.pkl"
+DEFAULT_ENSEMBL_MAPPING_FILE = Path(__file__).parent / "v1" / "ensembl_mapping_dictionary.pkl"
 class TranscriptomeTokenizer:
     def __init__(
         self,
         custom_attr_name_dict=None,
         nproc=1,
         chunk_size=512,
-        gene_median_file=GENE_MEDIAN_FILE,
-        token_dictionary_file=TOKEN_DICTIONARY_FILE,
+        model_input_size=2048,
+        special_token=False,
+        collapse_gene_ids=True,
+        gene_median_file=DEFAULT_GENE_MEDIAN_FILE,
+        token_dictionary_file=DEFAULT_TOKEN_DICTIONARY_FILE,
+        gene_mapping_file=DEFAULT_ENSEMBL_MAPPING_FILE,
     ):
         """
         Initialize tokenizer.
-
+        
         **Parameters:**
-
+        
         custom_attr_name_dict : None, dict
             | Dictionary of custom attributes to be added to the dataset.
-            | Keys are the names of the attributes in the loom/h5ad file.
-            | Values are the new names of the attributes in the dataset.
+            | Keys are the names of the attributes in the loom file.
+            | Values are the names of the attributes in the dataset.
         nproc : int
             | Number of processes to use for dataset mapping.
-        chunk_size: int = 512
+        chunk_size : int = 512
             | Chunk size for anndata tokenizer.
+        model_input_size : int = 4096
+            | Max input size of model to truncate input to.
+            | For the 30M model series, should be 2048. For the 95M model series, should be 4096.
+        special_token : bool = True
+            | Adds CLS token before and EOS token after rank value encoding.
+            | For the 30M model series, should be False. For the 95M model series, should be True.
+        collapse_gene_ids : bool = True
+            | Whether to collapse gene IDs based on gene mapping dictionary.
         gene_median_file : Path
             | Path to pickle file containing dictionary of non-zero median
             | gene expression values across Genecorpus-30M.
         token_dictionary_file : Path
             | Path to pickle file containing token dictionary (Ensembl IDs:token).
+        gene_mapping_file : None, Path
+            | Path to pickle file containing dictionary for collapsing gene IDs.
         """
+
         # dictionary of custom attributes {output dataset column name: input .loom column name}
         self.custom_attr_name_dict = custom_attr_name_dict
 
@@ -118,6 +333,12 @@ class TranscriptomeTokenizer:
 
         # chunk size for anndata tokenizer
         self.chunk_size = chunk_size
+
+        # input size for tokenization
+        self.model_input_size = model_input_size
+
+        # add CLS and EOS tokens
+        self.special_token = special_token
 
         # load dictionary of gene normalization factors
         # (non-zero median value of expression across Genecorpus-30M)
@@ -128,11 +349,46 @@ class TranscriptomeTokenizer:
         with open(token_dictionary_file, "rb") as f:
             self.gene_token_dict = pickle.load(f)
 
+        # check for special token in gene_token_dict
+        if self.special_token:
+            if ("<cls>" not in self.gene_token_dict.keys()) and (
+                "<eos>" not in self.gene_token_dict.keys()
+            ):
+                LOGGER.error(
+                    "<cls> and <eos> required in gene_token_dict when special_token = True."
+                )
+                raise
+
+        if not self.special_token:
+            if ("<cls>" in self.gene_token_dict.keys()) and (
+                "<eos>" in self.gene_token_dict.keys()
+            ):
+                LOGGER.warning(
+                    "<cls> and <eos> are in gene_token_dict but special_token = False. Please note that for 95M model series, special_token should be True."
+                )
+
+        # if collapsing duplicate gene IDs
+        self.collapse_gene_ids = collapse_gene_ids
+
+        # load gene mappings dictionary (Ensembl IDs:Ensembl ID)
+        if gene_mapping_file is not None:
+            with open(gene_mapping_file, "rb") as f:
+                self.gene_mapping_dict = pickle.load(f)
+        else:
+            self.gene_mapping_dict = {k: k for k, _ in self.gene_token_dict.items()}
+
         # gene keys for full vocabulary
-        self.gene_keys = list(self.gene_median_dict.keys())
+        self.gene_keys = list(self.gene_token_dict.keys())
+
+        #  Filter gene mapping dict for items that exist in gene_token_dict
+        gene_keys_set = set(self.gene_token_dict.keys())
+        self.gene_mapping_dict = {
+            k: v for k, v in self.gene_mapping_dict.items() if v in gene_keys_set
+        }
 
         # protein-coding and miRNA gene list dictionary for selecting .loom rows for tokenization
         self.genelist_dict = dict(zip(self.gene_keys, [True] * len(self.gene_keys)))
+
 
     def tokenize_data(
         self,
@@ -144,9 +400,9 @@ class TranscriptomeTokenizer:
     ):
         """
         Tokenize .loom files in data_directory and save as tokenized .dataset in output_directory.
-
+        
         **Parameters:**
-
+        
         data_directory : Path
             | Path to directory containing loom files or anndata files
         output_directory : Path
@@ -162,11 +418,14 @@ class TranscriptomeTokenizer:
             Path(data_directory), file_format
         )
         tokenized_dataset = self.create_dataset(
-            tokenized_cells, cell_metadata, use_generator=use_generator
+            tokenized_cells,
+            cell_metadata,
+            use_generator=use_generator,
         )
 
         output_path = (Path(output_directory) / output_prefix).with_suffix(".dataset")
-        tokenized_dataset.save_to_disk(output_path)
+        tokenized_dataset.save_to_disk(str(output_path))
+
 
     def tokenize_files(
         self, data_directory, file_format: Literal["loom", "h5ad"] = "loom"
@@ -204,45 +463,81 @@ class TranscriptomeTokenizer:
             raise
         return tokenized_cells, cell_metadata
 
-    def tokenize_anndata(self, adata: AnnData, target_sum=10_000):
+    def tokenize_anndata(self, adata_file_path, target_sum=10_000):
+        adata = sum_ensembl_ids(
+            adata_file_path,
+            self.collapse_gene_ids,
+            self.gene_mapping_dict,
+            self.gene_token_dict,
+            file_format="h5ad",
+            chunk_size=self.chunk_size,
+        )
 
-        # prepare custom attributes for output dataset
         if self.custom_attr_name_dict is not None:
-            # the key(s) are the name(s) of the obs column(s) in the loom/h5ad file
-            custom_keys = self.custom_attr_name_dict.keys()
-            # the values will be in the output dataset
             file_cell_metadata = {
-                attr_key: [] for attr_key in self.custom_attr_name_dict.values()
+                attr_key: [] for attr_key in self.custom_attr_name_dict.keys()
             }
-            
 
-        coding_miRNA_loc = np.where([self.genelist_dict.get(i, False) for i in adata.var["ensembl_id"]] )[0]
-        norm_factor_vector = np.array([self.gene_median_dict[i] for i in adata.var["ensembl_id"].iloc[coding_miRNA_loc]])
+        coding_miRNA_loc = np.where(
+            [self.genelist_dict.get(i, False) for i in adata.var["ensembl_id"]]
+        )[0]
+        norm_factor_vector = np.array(
+            [
+                self.gene_median_dict[i]
+                for i in adata.var["ensembl_id"].iloc[coding_miRNA_loc]
+            ]
+        )
         coding_miRNA_ids = adata.var["ensembl_id"].iloc[coding_miRNA_loc]
-        coding_miRNA_tokens = np.array([self.gene_token_dict[i] for i in coding_miRNA_ids])
+        coding_miRNA_tokens = np.array(
+            [self.gene_token_dict[i] for i in coding_miRNA_ids]
+        )
 
-        filter_pass_loc = self._get_filter_pass_loc(adata)        
+        try:
+            _ = adata.obs["filter_pass"]
+        except KeyError:
+            var_exists = False
+        else:
+            var_exists = True
+
+        if var_exists:
+            filter_pass_loc = np.where([i == 1 for i in adata.obs["filter_pass"]])[0]
+        elif not var_exists:
+            LOGGER.info(
+                f"{adata_file_path} has no column attribute 'filter_pass'; tokenizing all cells."
+            )
+            filter_pass_loc = np.array([i for i in range(adata.shape[0])])
 
         tokenized_cells = []
 
         for i in range(0, len(filter_pass_loc), self.chunk_size):
             idx = filter_pass_loc[i : i + self.chunk_size]
 
-            n_counts = adata[idx].obs["total_counts"].values[:, None]
-            X_view = adata[idx, coding_miRNA_loc].X
+            # Check if 'n_counts' exists in adata.obs
+            if 'n_counts' in adata.obs.columns:
+                n_counts = adata[idx].obs["n_counts"].values[:, None]
+            else:
+                # If 'n_counts' doesn't exist, calculate it as the sum of counts for each cell
+                n_counts = np.sum(adata[idx, :].X, axis=1)[:, None]
+
+            X_view0 = adata[idx, :].X
+            X_view = X_view0[:, coding_miRNA_loc]
             X_norm = X_view / n_counts * target_sum / norm_factor_vector
             X_norm = sp.csr_matrix(X_norm)
 
-            tokenized_cells += [rank_genes(X_norm[i].data, coding_miRNA_tokens[X_norm[i].indices]) for i in range(X_norm.shape[0]) ]
+            tokenized_cells += [
+                rank_genes(X_norm[i].data, coding_miRNA_tokens[X_norm[i].indices])
+                for i in range(X_norm.shape[0])
+            ]
 
             # add custom attributes for subview to dict
             if self.custom_attr_name_dict is not None:
-                for custom_key in custom_keys:
-                    file_cell_metadata[self.custom_attr_name_dict[custom_key]] += adata[idx].obs[custom_key].tolist()
+                for k in file_cell_metadata.keys():
+                    file_cell_metadata[k] += adata[idx].obs[k].tolist()
             else:
                 file_cell_metadata = None
 
         return tokenized_cells, file_cell_metadata
+    
 
     def tokenize_loom(self, loom_file_path, target_sum=10_000):
         if self.custom_attr_name_dict is not None:
@@ -250,26 +545,40 @@ class TranscriptomeTokenizer:
                 attr_key: [] for attr_key in self.custom_attr_name_dict.keys()
             }
 
+        dedup_filename = loom_file_path.with_name(loom_file_path.stem + "__dedup.loom")
+        loom_file_path = sum_ensembl_ids(
+            loom_file_path,
+            self.collapse_gene_ids,
+            self.gene_mapping_dict,
+            self.gene_token_dict,
+            file_format="loom",
+            chunk_size=self.chunk_size,
+        )
+
         with lp.connect(str(loom_file_path)) as data:
-            # define coordinates of detected protein-coding or miRNA genes and vector of their normalization factors
-            coding_miRNA_loc = np.where(
-                [self.genelist_dict.get(i, False) for i in data.ra["ensembl_id"]]
-            )[0]
-            norm_factor_vector = np.array(
-                [
-                    self.gene_median_dict[i]
-                    for i in data.ra["ensembl_id"][coding_miRNA_loc]
-                ]
-            )
-            coding_miRNA_ids = data.ra["ensembl_id"][coding_miRNA_loc]
-            coding_miRNA_tokens = np.array(
-                [self.gene_token_dict[i] for i in coding_miRNA_ids]
-            )
+            # Convert data.ra["ensembl_id"] to a numpy array
+            ensembl_ids = np.array(data.ra["ensembl_id"])
+            
+            # Create a boolean mask for coding_miRNA genes
+            coding_miRNA_mask = np.array([self.genelist_dict.get(i, False) for i in ensembl_ids])
+            coding_miRNA_loc = np.where(coding_miRNA_mask)[0]
+                    
+            norm_factor_vector = np.array([
+                self.gene_median_dict[i]
+                for i in ensembl_ids[coding_miRNA_loc]
+            ])
+            
+            coding_miRNA_ids = ensembl_ids[coding_miRNA_loc]
+            coding_miRNA_tokens = np.array([self.gene_token_dict[i] for i in coding_miRNA_ids])
+
+            if coding_miRNA_tokens.size == 1:
+                coding_miRNA_tokens = np.array([coding_miRNA_tokens.item()])
+
 
             # define coordinates of cells passing filters for inclusion (e.g. QC)
             try:
                 data.ca["filter_pass"]
-            except AttributeError:
+            except KeyError:
                 var_exists = False
             else:
                 var_exists = True
@@ -277,7 +586,9 @@ class TranscriptomeTokenizer:
             if var_exists:
                 filter_pass_loc = np.where([i == 1 for i in data.ca["filter_pass"]])[0]
             elif not var_exists:
-                LOGGER.info(f"{loom_file_path} has no column attribute 'filter_pass'; tokenizing all cells.")
+                LOGGER.info(
+                    f"{loom_file_path} has no column attribute 'filter_pass'; tokenizing all cells."
+                )
                 filter_pass_loc = np.array([i for i in range(data.shape[1])])
 
             # scan through .loom files and tokenize cells
@@ -309,6 +620,9 @@ class TranscriptomeTokenizer:
                 else:
                     file_cell_metadata = None
 
+        if str(dedup_filename) == str(loom_file_path):
+            os.remove(str(dedup_filename))
+
         return tokenized_cells, file_cell_metadata
 
     def create_dataset(
@@ -321,7 +635,7 @@ class TranscriptomeTokenizer:
         LOGGER.info("Creating dataset.")
         # create dict for dataset creation
         dataset_dict = {"input_ids": tokenized_cells}
-        if cell_metadata is not None:
+        if self.custom_attr_name_dict is not None:
             dataset_dict.update(cell_metadata)
 
         # create dataset
@@ -341,8 +655,22 @@ class TranscriptomeTokenizer:
                 example["input_ids_uncropped"] = example["input_ids"]
                 example["length_uncropped"] = len(example["input_ids"])
 
-            # Truncate/Crop input_ids to size 2,048
-            example["input_ids"] = example["input_ids"][0:2048]
+            # Truncate/Crop input_ids to input size
+            if self.special_token:
+                example["input_ids"] = example["input_ids"][
+                    0 : self.model_input_size - 2
+                ]  # truncate to leave space for CLS and EOS token
+                example["input_ids"] = np.insert(
+                    example["input_ids"], 0, self.gene_token_dict.get("<cls>")
+                )
+                example["input_ids"] = np.insert(
+                    example["input_ids"],
+                    len(example["input_ids"]),
+                    self.gene_token_dict.get("<eos>"),
+                )
+            else:
+                # Truncate/Crop input_ids to input size
+                example["input_ids"] = example["input_ids"][0 : self.model_input_size]
             example["length"] = len(example["input_ids"])
 
             return example
@@ -351,20 +679,3 @@ class TranscriptomeTokenizer:
             format_cell_features, num_proc=self.nproc
         )
         return output_dataset_truncated
-
-    def _get_filter_pass_loc(self, adata: AnnData) -> ndarray:
-        """
-        Get the indices of cells that pass the filter.
-
-        Parameters:
-            adata (AnnData): Annotated data object.
-
-        Returns:
-            filter_pass_loc (ndarray): Indices of cells where the 'filter_pass' is 1. 
-                If no 'filter_pass' column is found, return all indices. Ie. tokenize all cells.
-        """
-        filter_pass_loc = np.where(adata.obs.get("filter_pass", 0) == 1)[0]
-        if len(filter_pass_loc) == 0:
-            LOGGER.info("Anndata has no column attribute 'filter_pass'. Passing all cells for tokenization.")
-            filter_pass_loc = np.arange(adata.shape[0])
-        return filter_pass_loc

--- a/helical/models/geneformer/geneformer_utils.py
+++ b/helical/models/geneformer/geneformer_utils.py
@@ -165,15 +165,14 @@ def quant_layers(model):
 def get_model_input_size(model):
     return int(re.split("\(|,", str(model.bert.embeddings.position_embeddings))[1])
 
-def load_model(model_type, model_directory):
+def load_model(model_type, model_directory, device):
     if model_type == "Pretrained":
         model = BertForMaskedLM.from_pretrained(
             model_directory, output_hidden_states=True, output_attentions=False
         )
     # put the model in eval mode for fwd pass and load onto the GPU if available
     model.eval()
-    if torch.cuda.is_available():
-        model = model.to("cuda:0")
+    model = model.to(device)
     return model
 
 def pad_tensor(tensor, pad_token_id, max_len):

--- a/helical/models/geneformer/geneformer_utils.py
+++ b/helical/models/geneformer/geneformer_utils.py
@@ -45,14 +45,35 @@ def get_embs(
     layer_to_quant,
     pad_token_id,
     forward_batch_size,
+    gene_token_dict,
     device,
     silent=False,
     
 ):
     model_input_size = get_model_input_size(model)
     total_batch_length = len(filtered_input_data)
-
     embs_list = []
+
+    #  Check if CLS and EOS token is present in the token dictionary
+    cls_present = any("<cls>" in key for key in gene_token_dict.keys())
+    eos_present = any("<eos>" in key for key in gene_token_dict.keys())
+    if emb_mode == "cls":
+        assert cls_present, "<cls> token missing in token dictionary"
+        # Check to make sure that the first token of the filtered input data is cls token
+        cls_token_id = gene_token_dict["<cls>"]
+        assert (
+            filtered_input_data["input_ids"][0][0] == cls_token_id
+        ), "First token is not <cls> token value"
+    elif emb_mode == "cell":
+        if cls_present:
+            logger.warning(
+                "CLS token present in token dictionary, excluding from average."
+            )
+        if eos_present:
+            logger.warning(
+                "EOS token present in token dictionary, excluding from average."
+            )
+
     overall_max_len = 0
     for i in trange(0, total_batch_length, forward_batch_size, leave=(not silent)):
         max_range = min(i + forward_batch_size, total_batch_length)
@@ -67,18 +88,35 @@ def get_embs(
         input_data_minibatch = pad_tensor_list(
             input_data_minibatch, max_len, pad_token_id, model_input_size
         ).to(device)
+
         with torch.no_grad():
             outputs = model(
                 input_ids=input_data_minibatch,
                 attention_mask=gen_attention_mask(minibatch),
             )
+
         embs_i = outputs.hidden_states[layer_to_quant]
-        
+
         if emb_mode == "cell":
-            mean_embs = mean_nonpadding_embs(embs_i, original_lens)
+            if cls_present:
+                non_cls_embs = embs_i[:, 1:, :]  # Get all layers except the cls embs
+                if eos_present:
+                    mean_embs = mean_nonpadding_embs(non_cls_embs, original_lens - 2)
+                else:
+                    mean_embs = mean_nonpadding_embs(non_cls_embs, original_lens - 1)
+            else:
+                mean_embs = mean_nonpadding_embs(embs_i, original_lens)
+            
             embs_list.append(mean_embs)
+            del mean_embs
+
         elif emb_mode == "gene":
                 embs_list.append(embs_i)
+        
+        elif emb_mode == "cls":
+            cls_embs = embs_i[:, 0, :].clone().detach()  # CLS token layer
+            embs_list.append(cls_embs)
+            del cls_embs
 
         overall_max_len = max(overall_max_len, max_len)
         del outputs
@@ -86,9 +124,9 @@ def get_embs(
         del input_data_minibatch
         del embs_i
 
-        # torch.cuda.empty_cache()
+        torch.cuda.empty_cache()
 
-    if emb_mode == "cell":
+    if emb_mode == "cell" or emb_mode == "cls":
         embs_stack = torch.cat(embs_list, dim=0)
     elif emb_mode == "gene":
         embs_stack = pad_tensor_list(
@@ -132,9 +170,10 @@ def load_model(model_type, model_directory):
         model = BertForMaskedLM.from_pretrained(
             model_directory, output_hidden_states=True, output_attentions=False
         )
-    # put the model in eval mode for fwd pass
+    # put the model in eval mode for fwd pass and load onto the GPU if available
     model.eval()
-    # model = model.to("cuda:0")
+    if torch.cuda.is_available():
+        model = model.to("cuda:0")
     return model
 
 def pad_tensor(tensor, pad_token_id, max_len):

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -19,17 +19,26 @@ import os
 LOGGER = logging.getLogger(__name__)
 class Geneformer(HelicalRNAModel):
     """Geneformer Model. 
-    The Geneformer Model is a transformer-based model that can be used to extract gene embeddings from single-cell RNA-seq data. 
+    The Geneformer Model is a transformer-based model that can be used to extract gene embeddings from single-cell RNA-seq data. Both versions are made available through this interface.
+    For a detailed explanation of the difference between both versions, please refer to the model card, here: https://helical.readthedocs.io/en/latest/docs/Geneformer.html
 
     Example
     -------
-    >>> from helical.models import Geneformer,GeneformerConfig
+    >>> from helical.models import Geneformer, GeneformerConfig
     >>> import anndata as ad
-    >>> geneformer_config=GeneformerConfig(batch_size=10)
-    >>> geneformer = Geneformer(configurer=geneformer_config)
+    >>> 
+    >>> # For Version 1.0
+    >>> geneformer_config_v1 = GeneformerConfig(model_name="gf-12L-30M-i2048", batch_size=10)
+    >>> geneformer_v1 = Geneformer(configurer=geneformer_config_v1)
+    >>> 
+    >>> # For Version 2.0
+    >>> geneformer_config_v2 = GeneformerConfig(model_name="gf-12L-95M-i4096", batch_size=10)
+    >>> geneformer_v2 = Geneformer(configurer=geneformer_config_v2)
+    >>> 
+    >>> # Example usage (same for both versions)
     >>> ann_data = ad.read_h5ad("./data/10k_pbmcs_proc.h5ad")
-    >>> dataset = geneformer.process_data(ann_data[:100])
-    >>> embeddings = geneformer.get_embeddings(dataset)
+    >>> dataset = geneformer_v2.process_data(ann_data[:100])
+    >>> embeddings = geneformer_v2.get_embeddings(dataset)
 
     Parameters
     ----------
@@ -42,8 +51,8 @@ class Geneformer(HelicalRNAModel):
 
     Notes
     -----
-    It has been published in this `Nature Paper <https://www.nature.com/articles/s41586-023-06139-9.epdf?sharing_token=u_5LUGVkd3A8zR-f73lU59RgN0jAjWel9jnR3ZoTv0N2UB4yyXENUK50s6uqjXH69sDxh4Z3J4plYCKlVME-W2WSuRiS96vx6t5ex2-krVDS46JkoVvAvJyWtYXIyj74pDWn_DutZq1oAlDaxfvBpUfSKDdBPJ8SKlTId8uT47M%3D>`_. 
-    A second updated version of the model has been published in https://www.biorxiv.org/content/10.1101/2024.08.16.608180v1.full.pdf
+    The first version of the model is published in this `Nature Paper <https://www.nature.com/articles/s41586-023-06139-9.epdf?sharing_token=u_5LUGVkd3A8zR-f73lU59RgN0jAjWel9jnR3ZoTv0N2UB4yyXENUK50s6uqjXH69sDxh4Z3J4plYCKlVME-W2WSuRiS96vx6t5ex2-krVDS46JkoVvAvJyWtYXIyj74pDWn_DutZq1oAlDaxfvBpUfSKDdBPJ8SKlTId8uT47M%3D>`_. 
+    The second version of the model is available at https://www.biorxiv.org/content/10.1101/2024.08.16.608180v1.full.pdf
     We use the implementation from the `Geneformer <https://huggingface.co/ctheodoris/Geneformer/tree/main>`_ repository.
 
     """

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -38,20 +38,21 @@ class Geneformer(HelicalRNAModel):
     >>> from helical.models import Geneformer, GeneformerConfig
     >>> import anndata as ad
     >>> 
-    >>> # For Version 1.0
-    >>> geneformer_config_v1 = GeneformerConfig(model_name="gf-12L-30M-i2048", batch_size=10)
-    >>> geneformer_v1 = Geneformer(configurer=geneformer_config_v1)
-    >>> 
     >>> # For Version 2.0
     >>> geneformer_config_v2 = GeneformerConfig(model_name="gf-12L-95M-i4096", batch_size=10)
     >>> geneformer_v2 = Geneformer(configurer=geneformer_config_v2)
+    >>>
+    >>> # You can use other model names in the config, such as:
+    >>> # "gf-12L-30M-i2048" (Version 1.0)
+    >>> # "gf-12L-95M-i4096-CLcancer" (Version 2.0, Cancer-tuned)
+    >>> # "gf-20L-95M-i4096" (Version 2.0, 20-layer model)
     >>> 
     >>> # Example usage for base pretrained model (for general transcriptomic analysis, v1 and v2)
     >>> ann_data = ad.read_h5ad("general_dataset.h5ad")
     >>> dataset = geneformer_v2.process_data(ann_data)
     >>> embeddings = geneformer_v2.get_embeddings(dataset)
     >>> print("Base model embeddings shape:", embeddings.shape)
-
+    >>>
     >>> # Example usage for cancer-tuned model (for cancer-specific analysis)
     >>> cancer_ann_data = ad.read_h5ad("cancer_dataset.h5ad")
     >>> cancer_dataset = geneformer_v2_cancer.process_data(cancer_ann_data)


### PR DESCRIPTION
Integrated the new tokenizer and model code for the newly published version of Geneformer (https://www.biorxiv.org/content/10.1101/2024.08.16.608180v1.full.pdf), also including minor changes to the original code for better compatibility with the package.

Wrote a new config for geneformer to accommodate for both versions, including different models (number of layers etc) for each version. The exact files to download for each configuration is handled under the hood. The user only has to specify model name from amongst the available ones (gf-12L-30M-i2048, gf-12L-95m-i4096 etc)

Have also adapted existing unit tests and wrote additional ones for the newly added functions.