### PR TITLE
Fix mamba-ssm integration in release Pypi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,12 +22,9 @@ jobs:
       - name: Install dependencies
         run: |
             pip install -r requirements-dev.txt
+            # Currently, the self-hosted runner uses a pre-installed version of mamba-ssm (v2.2.2). Using the latest version (v2.2.4) breaks the pip installation.
+            # TODO fix the installation helical[mamba-ssm], and add it in the GitHub actions (CI/CD pipeline).
             pip install .
-            
-      # First download before tests as they make use of the downloaded files 
-      - name: Download all files
-        run: |
-          python ci/download_all.py
 
       - name: Execute unittests
         run: |
@@ -123,6 +120,11 @@ jobs:
       - name: Install dependencies
         run: |
             pip install -r requirements-dev.txt
+
+      # First download before tests as they make use of the downloaded files 
+      - name: Download all files
+        run: |
+          python ci/download_all.py
             
       - name: Reduce datasets to speedup checks
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,7 @@ on:
 
 jobs:
   tests:
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, self-hosted]
-    runs-on: ${{ matrix.os }}
+    runs-on: self-hosted
     env:
       CUDA_VISIBLE_DEVICES: 0
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   tests:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ubuntu-24.04]
     env:
       CUDA_VISIBLE_DEVICES: 0
     steps:
@@ -50,6 +50,7 @@ jobs:
 
   integration-tests:
     needs: tests
+    # Integration tests require GPU(s), hence only run on self-hosted runners
     runs-on: self-hosted
     steps:
       - name: Checkout repository
@@ -132,6 +133,7 @@ jobs:
 
   notebooks:
     needs: tests
+    # Notebooks require GPU(s), hence only run on self-hosted runners
     runs-on: self-hosted
     steps:
       - name: Checkout repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Execute Geneformer v1
         run: |
           python examples/run_models/run_geneformer.py ++model_name="gf-12L-30M-i2048"
-  
+
       - name: Fine-tune Geneformer v1
         run: |
           python examples/fine_tune_models/fine_tune_geneformer.py ++model_name="gf-12L-30M-i2048"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,11 @@ jobs:
             # Currently, the self-hosted runner uses a pre-installed version of mamba-ssm (v2.2.2). Using the latest version (v2.2.4) breaks the pip installation.
             # TODO fix the installation helical[mamba-ssm], and add it in the GitHub actions (CI/CD pipeline).
             pip install .
+            
+      # First download before tests as they make use of the downloaded files 
+      - name: Download all files
+        run: |
+          python ci/download_all.py
 
       - name: Execute unittests
         run: |
@@ -105,7 +110,7 @@ jobs:
           pip install scanorama
           python examples/run_benchmark.py
 
-  notebooks:
+  integration-tests:
     needs: tests
     runs-on: self-hosted
     steps:
@@ -121,10 +126,25 @@ jobs:
         run: |
             pip install -r requirements-dev.txt
 
-      # First download before tests as they make use of the downloaded files 
-      - name: Download all files
+      - name: Execute Geneformer v1
         run: |
-          python ci/download_all.py
+          python examples/run_models/run_geneformer.py ++model_name="gf-12L-30M-i2048"
+
+  notebooks:
+    needs: tests
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.8
+
+      - name: Install dependencies
+        run: |
+            pip install -r requirements-dev.txt
             
       - name: Reduce datasets to speedup checks
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
             pip install -r requirements-dev.txt
             # Currently, the self-hosted runner uses a pre-installed version of mamba-ssm (v2.2.2). Using the latest version (v2.2.4) breaks the pip installation.
-            # TODO fix the installation helical[mamba-ssm], and add it in the GitHub actions (CI/CD pipeline).
+            # TODO fix the installation of helical[mamba-ssm], and add it in the GitHub actions (CI/CD pipeline).
             pip install .
             
       # First download before tests as they make use of the downloaded files 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,6 @@ jobs:
 
   integration-tests:
     needs: tests
-    # Integration tests require GPU(s), hence only run on self-hosted runners
     runs-on: self-hosted
     steps:
       - name: Checkout repository
@@ -133,7 +132,6 @@ jobs:
 
   notebooks:
     needs: tests
-    # Notebooks require GPU(s), hence only run on self-hosted runners
     runs-on: self-hosted
     steps:
       - name: Checkout repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,6 +125,11 @@ jobs:
       - name: Install dependencies
         run: |
             pip install -r requirements-dev.txt
+      
+      # First download before tests as they make use of the downloaded files 
+      - name: Download all files
+        run: |
+          python ci/download_all.py
 
       - name: Execute Geneformer v1
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,11 +48,31 @@ jobs:
       #     pytest-coverage-path: ./pytest-coverage.txt
       #     junitxml-path: ./pytest.xml
 
+  integration-tests:
+    needs: tests
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.8
+
+      - name: Install dependencies
+        run: |
+            pip install -r requirements-dev.txt
+      
+      # First download before tests as they make use of the downloaded files 
+      - name: Download all files
+        run: |
+          python ci/download_all.py
 
       - name: Execute Geneformer v1
         run: |
           python examples/run_models/run_geneformer.py ++model_name="gf-12L-30M-i2048"
-
+  
       - name: Fine-tune Geneformer v1
         run: |
           python examples/fine_tune_models/fine_tune_geneformer.py ++model_name="gf-12L-30M-i2048"
@@ -109,31 +129,6 @@ jobs:
         run: |
           pip install scanorama
           python examples/run_benchmark.py
-
-  integration-tests:
-    needs: tests
-    runs-on: self-hosted
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.11.8
-
-      - name: Install dependencies
-        run: |
-            pip install -r requirements-dev.txt
-      
-      # First download before tests as they make use of the downloaded files 
-      - name: Download all files
-        run: |
-          python ci/download_all.py
-
-      - name: Execute Geneformer v1
-        run: |
-          python examples/run_models/run_geneformer.py ++model_name="gf-12L-30M-i2048"
 
   notebooks:
     needs: tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   tests:
-    runs-on: [self-hosted, ubuntu-24.04]
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, self-hosted]
+    runs-on: ${{ matrix.os }}
     env:
       CUDA_VISIBLE_DEVICES: 0
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,21 @@ permissions:
   contents: write
 
 jobs:
+  fresh-install:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.8
+
+      - name: Install dependencies
+        run: |
+            pip install .
+
   tests:
     runs-on: self-hosted
     env:
@@ -25,6 +40,8 @@ jobs:
       - name: Install dependencies
         run: |
             pip install -r requirements-dev.txt
+            # Currently, the self-hosted runner uses a pre-installed version of mamba-ssm (v2.2.2). Using the latest version (v2.2.4) breaks the pip installation.
+            # TODO fix the installation helical[mamba-ssm], and add it in the GitHub actions (CI/CD pipeline).
             pip install .
             
       # First download before tests as they make use of the downloaded files 
@@ -42,10 +59,32 @@ jobs:
           name: coverage-report
           path: html_cov/
 
+  integration-tests:
+    needs: tests
+    # Integration tests require GPU(s), hence only run on self-hosted runners
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.8
+
+      - name: Install dependencies
+        run: |
+            pip install -r requirements-dev.txt
+      
+      # First download before tests as they make use of the downloaded files 
+      - name: Download all files
+        run: |
+          python ci/download_all.py
+
       - name: Execute Geneformer v1
         run: |
           python examples/run_models/run_geneformer.py ++model_name="gf-12L-30M-i2048"
-
+  
       - name: Fine-tune Geneformer v1
         run: |
           python examples/fine_tune_models/fine_tune_geneformer.py ++model_name="gf-12L-30M-i2048"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Execute Geneformer v1
         run: |
           python examples/run_models/run_geneformer.py ++model_name="gf-12L-30M-i2048"
-  
+
       - name: Fine-tune Geneformer v1
         run: |
           python examples/fine_tune_models/fine_tune_geneformer.py ++model_name="gf-12L-30M-i2048"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
             pip install -r requirements-dev.txt
             # Currently, the self-hosted runner uses a pre-installed version of mamba-ssm (v2.2.2). Using the latest version (v2.2.4) breaks the pip installation.
-            # TODO fix the installation helical[mamba-ssm], and add it in the GitHub actions (CI/CD pipeline).
+            # TODO fix the installation of helical[mamba-ssm], and add it in the GitHub actions (CI/CD pipeline).
             pip install .
             
       # First download before tests as they make use of the downloaded files 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,6 @@ jobs:
 
   integration-tests:
     needs: tests
-    # Integration tests require GPU(s), hence only run on self-hosted runners
     runs-on: self-hosted
     steps:
       - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helical"
-version = "0.0.1a10"
+version = "0.0.1a11"
 authors = [
   { name="Helical Team", email="support@helical-ai.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mamba-ssm = [
-    'mamba-ssm @ git+https://github.com/state-spaces/mamba.git@v2.2.3',
+    'mamba-ssm==2.2.4',
     'causal-conv1d==1.4.0',
 ]
 


### PR DESCRIPTION
* Replacing mamba-ssm installation from Git with Pypi. This is done because when releasing the Helical package to PyPI, it complains about the git+ endpoint. To solve this we install the latest version of mama-ssm (v2.2.4) recently release. However, for now in the CI/CD we still use the version v2.2.2 (to be solved later).
* Split the CI/CD into unittests and integration tests in main.yml and release.yml
* Introduce a new type of tests in the release.yml, where a fresh install of the Helical library is done on an Ubuntu runner