### PR TITLE
Test models using local files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,59 +49,59 @@ jobs:
 
       - name: Execute Geneformer v1
         run: |
-          python examples/run_models/run_geneformer.py ++model_name="gf-12L-30M-i2048"
+          python examples/run_models/run_geneformer.py ++model_name="gf-12L-30M-i2048" ++device="cuda"
 
       - name: Fine-tune Geneformer v1
         run: |
-          python examples/fine_tune_models/fine_tune_geneformer.py ++model_name="gf-12L-30M-i2048"
+          python examples/fine_tune_models/fine_tune_geneformer.py ++model_name="gf-12L-30M-i2048" ++device="cuda"
 
       - name: Execute Geneformer v2
         run: |
-          python examples/run_models/run_geneformer.py ++model_name="gf-12L-95M-i4096"
+          python examples/run_models/run_geneformer.py ++model_name="gf-12L-95M-i4096" ++device="cuda"
 
       - name: Fine-tune Geneformer v2
         run: |
-          python examples/fine_tune_models/fine_tune_geneformer.py ++model_name="gf-12L-30M-i2048"
+          python examples/fine_tune_models/fine_tune_geneformer.py ++model_name="gf-12L-30M-i2048" ++device="cuda"
 
       - name: Execute scGPT
         run: |
-          python examples/run_models/run_scgpt.py
+          python examples/run_models/run_scgpt.py ++device="cuda"
 
       - name: Fine-tune scGPT
         run: |
-          python examples/fine_tune_models/fine_tune_scgpt.py
+          python examples/fine_tune_models/fine_tune_scgpt.py ++device="cuda"
 
       - name: Execute UCE
         run: |
-          python examples/run_models/run_uce.py
+          python examples/run_models/run_uce.py ++device="cuda"
 
       - name: Fine-tune UCE
         run: |
-          python examples/fine_tune_models/fine_tune_UCE.py
+          python examples/fine_tune_models/fine_tune_UCE.py ++device="cuda"
 
       - name: Execute Hyena
         run: |
-          python examples/run_models/run_hyena_dna.py
+          python examples/run_models/run_hyena_dna.py ++device="cuda"
 
       - name: Execute Hyena
         run: |
-          python examples/fine_tune_models/fine_tune_hyena_dna.py
+          python examples/fine_tune_models/fine_tune_hyena_dna.py ++device="cuda"
 
       - name: Execute Helix-mRNA
         run: |
-          python examples/run_models/run_helix_mrna.py
+          python examples/run_models/run_helix_mrna.py ++device="cuda"
 
       - name: Fine-tune Helix-mRNA
         run: |
-          python examples/fine_tune_models/fine_tune_helix_mrna.py
+          python examples/fine_tune_models/fine_tune_helix_mrna.py ++device="cuda"
 
       - name: Execute Mamba2-mRNA
         run: |
-          python examples/run_models/run_mamba2_mrna.py
+          python examples/run_models/run_mamba2_mrna.py ++device="cuda"
 
       - name: Fine-tune Mamba2-mRNA
         run: |
-          python examples/fine_tune_models/fine_tune_mamba2_mrna.py
+          python examples/fine_tune_models/fine_tune_mamba2_mrna.py ++device="cuda"
 
       - name: Execute benchmarking
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,59 +44,59 @@ jobs:
 
       - name: Execute Geneformer v1
         run: |
-          python examples/run_models/run_geneformer.py ++model_name="gf-12L-30M-i2048"
+          python examples/run_models/run_geneformer.py ++model_name="gf-12L-30M-i2048" ++device="cuda"
 
       - name: Fine-tune Geneformer v1
         run: |
-          python examples/fine_tune_models/fine_tune_geneformer.py ++model_name="gf-12L-30M-i2048"
+          python examples/fine_tune_models/fine_tune_geneformer.py ++model_name="gf-12L-30M-i2048" ++device="cuda"
 
       - name: Execute Geneformer v2
         run: |
-          python examples/run_models/run_geneformer.py ++model_name="gf-12L-95M-i4096"
+          python examples/run_models/run_geneformer.py ++model_name="gf-12L-95M-i4096" ++device="cuda"
 
       - name: Fine-tune Geneformer v2
         run: |
-          python examples/fine_tune_models/fine_tune_geneformer.py ++model_name="gf-12L-30M-i2048"
+          python examples/fine_tune_models/fine_tune_geneformer.py ++model_name="gf-12L-30M-i2048" ++device="cuda"
 
       - name: Execute scGPT
         run: |
-          python examples/run_models/run_scgpt.py
+          python examples/run_models/run_scgpt.py ++device="cuda"
 
       - name: Fine-tune scGPT
         run: |
-          python examples/fine_tune_models/fine_tune_scgpt.py
+          python examples/fine_tune_models/fine_tune_scgpt.py ++device="cuda"
 
       - name: Execute UCE
         run: |
-          python examples/run_models/run_uce.py
+          python examples/run_models/run_uce.py ++device="cuda"
 
       - name: Fine-tune UCE
         run: |
-          python examples/fine_tune_models/fine_tune_UCE.py
+          python examples/fine_tune_models/fine_tune_UCE.py ++device="cuda"
 
       - name: Execute Hyena
         run: |
-          python examples/run_models/run_hyena_dna.py
+          python examples/run_models/run_hyena_dna.py ++device="cuda"
 
       - name: Execute Hyena
         run: |
-          python examples/fine_tune_models/fine_tune_hyena_dna.py
+          python examples/fine_tune_models/fine_tune_hyena_dna.py ++device="cuda"
 
       - name: Execute Helix-mRNA
         run: |
-          python examples/run_models/run_helix_mrna.py
+          python examples/run_models/run_helix_mrna.py ++device="cuda"
 
       - name: Fine-tune Helix-mRNA
         run: |
-          python examples/fine_tune_models/fine_tune_helix_mrna.py
+          python examples/fine_tune_models/fine_tune_helix_mrna.py ++device="cuda"
 
       - name: Execute Mamba2-mRNA
         run: |
-          python examples/run_models/run_mamba2_mrna.py
+          python examples/run_models/run_mamba2_mrna.py ++device="cuda"
 
       - name: Fine-tune Mamba2-mRNA
         run: |
-          python examples/fine_tune_models/fine_tune_mamba2_mrna.py
+          python examples/fine_tune_models/fine_tune_mamba2_mrna.py ++device="cuda"
 
       - name: Execute benchmarking
         run: |

--- a/examples/fine_tune_models/fine_tune_UCE.py
+++ b/examples/fine_tune_models/fine_tune_UCE.py
@@ -12,7 +12,7 @@ def run_fine_tuning(cfg: DictConfig):
     # hf_dataset = load_dataset("helical-ai/yolksac_human",split="train[:5%]", trust_remote_code=True, download_mode="reuse_cache_if_exists")
     # ann_data = get_anndata_from_hf_dataset(hf_dataset)
 
-    ann_data = ad.read_h5ad("../run_models/yolksac_human.h5ad")
+    ann_data = ad.read_h5ad("./yolksac_human.h5ad")
 
     cell_types = ann_data.obs["LVL1"][:10].tolist()
 

--- a/examples/fine_tune_models/fine_tune_UCE.py
+++ b/examples/fine_tune_models/fine_tune_UCE.py
@@ -1,13 +1,18 @@
 from helical import UCEConfig, UCEFineTuningModel
 from helical.utils import get_anndata_from_hf_dataset
 from datasets import load_dataset
+import anndata as ad
 from omegaconf import DictConfig
 import hydra
 
 @hydra.main(version_base=None, config_path="../run_models/configs", config_name="uce_config")
 def run_fine_tuning(cfg: DictConfig):
-    hf_dataset = load_dataset("helical-ai/yolksac_human",split="train[:5%]", trust_remote_code=True, download_mode="reuse_cache_if_exists")
-    ann_data = get_anndata_from_hf_dataset(hf_dataset)
+    
+    # either load via huggingface
+    # hf_dataset = load_dataset("helical-ai/yolksac_human",split="train[:5%]", trust_remote_code=True, download_mode="reuse_cache_if_exists")
+    # ann_data = get_anndata_from_hf_dataset(hf_dataset)
+
+    ann_data = ad.read_h5ad("../run_models/yolksac_human.h5ad")
 
     cell_types = ann_data.obs["LVL1"][:10].tolist()
 

--- a/examples/fine_tune_models/fine_tune_geneformer.py
+++ b/examples/fine_tune_models/fine_tune_geneformer.py
@@ -7,7 +7,8 @@ from omegaconf import DictConfig
 
 @hydra.main(version_base=None, config_path="../run_models/configs", config_name="geneformer_config")
 def run_fine_tuning(cfg: DictConfig):
-    # Option to download from HuggingFace
+    
+    # either load via huggingface
     # hf_dataset = load_dataset("helical-ai/yolksac_human",split="train[:5%]", trust_remote_code=True, download_mode="reuse_cache_if_exists")
     # ann_data = get_anndata_from_hf_dataset(hf_dataset)
     ann_data = ad.read_h5ad("../run_models/yolksac_human.h5ad")

--- a/examples/fine_tune_models/fine_tune_geneformer.py
+++ b/examples/fine_tune_models/fine_tune_geneformer.py
@@ -11,7 +11,7 @@ def run_fine_tuning(cfg: DictConfig):
     # either load via huggingface
     # hf_dataset = load_dataset("helical-ai/yolksac_human",split="train[:5%]", trust_remote_code=True, download_mode="reuse_cache_if_exists")
     # ann_data = get_anndata_from_hf_dataset(hf_dataset)
-    ann_data = ad.read_h5ad("../run_models/yolksac_human.h5ad")
+    ann_data = ad.read_h5ad("./yolksac_human.h5ad")
 
     cell_types = list(ann_data.obs["LVL1"][:10])
     label_set = set(cell_types)

--- a/examples/fine_tune_models/fine_tune_geneformer.py
+++ b/examples/fine_tune_models/fine_tune_geneformer.py
@@ -1,14 +1,16 @@
 from helical import GeneformerConfig, GeneformerFineTuningModel
 from helical.utils import get_anndata_from_hf_dataset
 from datasets import load_dataset
+import anndata as ad
 import hydra
 from omegaconf import DictConfig
 
 @hydra.main(version_base=None, config_path="../run_models/configs", config_name="geneformer_config")
 def run_fine_tuning(cfg: DictConfig):
-                            
-    hf_dataset = load_dataset("helical-ai/yolksac_human",split="train[:5%]", trust_remote_code=True, download_mode="reuse_cache_if_exists")
-    ann_data = get_anndata_from_hf_dataset(hf_dataset)
+    # Option to download from HuggingFace
+    # hf_dataset = load_dataset("helical-ai/yolksac_human",split="train[:5%]", trust_remote_code=True, download_mode="reuse_cache_if_exists")
+    # ann_data = get_anndata_from_hf_dataset(hf_dataset)
+    ann_data = ad.read_h5ad("../run_models/yolksac_human.h5ad")
 
     cell_types = list(ann_data.obs["LVL1"][:10])
     label_set = set(cell_types)

--- a/examples/fine_tune_models/fine_tune_scgpt.py
+++ b/examples/fine_tune_models/fine_tune_scgpt.py
@@ -8,6 +8,8 @@ import hydra
 
 @hydra.main(version_base=None, config_path="../run_models/configs", config_name="scgpt_config")
 def run_fine_tuning(cfg: DictConfig):
+
+    # either load via huggingface
     # hf_dataset = load_dataset("helical-ai/yolksac_human",split="train[:5%]", trust_remote_code=True, download_mode="reuse_cache_if_exists")
     # ann_data = get_anndata_from_hf_dataset(hf_dataset)
 

--- a/examples/fine_tune_models/fine_tune_scgpt.py
+++ b/examples/fine_tune_models/fine_tune_scgpt.py
@@ -1,14 +1,17 @@
 from helical import scGPTConfig, scGPTFineTuningModel
 from helical.utils import get_anndata_from_hf_dataset
 from datasets import load_dataset
+import anndata as ad
 from omegaconf import DictConfig
 import hydra
 
 
 @hydra.main(version_base=None, config_path="../run_models/configs", config_name="scgpt_config")
 def run_fine_tuning(cfg: DictConfig):
-    hf_dataset = load_dataset("helical-ai/yolksac_human",split="train[:5%]", trust_remote_code=True, download_mode="reuse_cache_if_exists")
-    ann_data = get_anndata_from_hf_dataset(hf_dataset)
+    # hf_dataset = load_dataset("helical-ai/yolksac_human",split="train[:5%]", trust_remote_code=True, download_mode="reuse_cache_if_exists")
+    # ann_data = get_anndata_from_hf_dataset(hf_dataset)
+
+    ann_data = ad.read_h5ad("../run_models/yolksac_human.h5ad")
 
     cell_types = ann_data.obs["LVL1"][:10].tolist()
     label_set = set(cell_types)

--- a/examples/fine_tune_models/fine_tune_scgpt.py
+++ b/examples/fine_tune_models/fine_tune_scgpt.py
@@ -13,7 +13,7 @@ def run_fine_tuning(cfg: DictConfig):
     # hf_dataset = load_dataset("helical-ai/yolksac_human",split="train[:5%]", trust_remote_code=True, download_mode="reuse_cache_if_exists")
     # ann_data = get_anndata_from_hf_dataset(hf_dataset)
 
-    ann_data = ad.read_h5ad("../run_models/yolksac_human.h5ad")
+    ann_data = ad.read_h5ad("./yolksac_human.h5ad")
 
     cell_types = ann_data.obs["LVL1"][:10].tolist()
     label_set = set(cell_types)

--- a/examples/run_models/configs/geneformer_config.yaml
+++ b/examples/run_models/configs/geneformer_config.yaml
@@ -2,5 +2,5 @@ model_name: "gf-12L-30M-i2048"
 batch_size: 24
 emb_layer: -1
 emb_mode: "cell"
-device: "cuda"
+device: "cpu"
 accelerator: False

--- a/examples/run_models/configs/helix_mrna_config.yaml
+++ b/examples/run_models/configs/helix_mrna_config.yaml
@@ -1,3 +1,3 @@
 batch_size: 10
-device: "cuda"
+device: "cpu"
 max_length: 100

--- a/examples/run_models/configs/hyena_dna_config.yaml
+++ b/examples/run_models/configs/hyena_dna_config.yaml
@@ -11,7 +11,7 @@ checkpoint_mixer: False
 checkpoint_mlp: False
 pad_vocab_size_multiple: 8
 return_hidden_state: True
-device: "cuda"
+device: "cpu"
 layer: 
     "_name_": "hyena"
     "emb_dim": 5

--- a/examples/run_models/configs/mamba2_mrna_config.yaml
+++ b/examples/run_models/configs/mamba2_mrna_config.yaml
@@ -1,3 +1,3 @@
 batch_size: 10
-device: "cuda"
+device: "cpu"
 max_length: 100

--- a/examples/run_models/configs/scgpt_config.yaml
+++ b/examples/run_models/configs/scgpt_config.yaml
@@ -11,5 +11,5 @@ mask_value: -1
 pad_value: -2
 world_size: 8
 accelerator: False
-device: "cuda"
+device: "cpu"
 use_fast_transformer: False

--- a/examples/run_models/configs/uce_config.yaml
+++ b/examples/run_models/configs/uce_config.yaml
@@ -14,5 +14,5 @@ output_dim: 1280
 d_hid: 5120
 token_dim: 5120
 multi_gpu: False
-device: "cuda"
+device: "cpu"
 accelerator: False


### PR DESCRIPTION
- Use downloaded local files for the running of fine-tuning models because downloading from HF for each test is slow
- Make default behaviour cpu for run_models and fine_tune_models
- Add hydra override to set this config to cuda for git workflow tests