### PR TITLE
Fix broken model card link

### DIFF
--- a/ci/tests/test_benchmark/test_benchmark.py
+++ b/ci/tests/test_benchmark/test_benchmark.py
@@ -65,7 +65,7 @@ def test_evaluate_classification(mocker):
 def test_evaluate_integration(mocker):
     """
     Test that the integration evaluation function returns the expected results.
-    We follow the approach from scGPT to evaluate the integration based on the bioloical conservation
+    We follow the approach from scGPT to evaluate the integration based on the biological conservation
     and the batch correction. The metrics we are interested in are:
     - ARI (Adjusted Rand Index)
     - NMI (Normalized Mutual Information)

--- a/ci/tests/test_benchmark/test_classification/test_classifier.py
+++ b/ci/tests/test_benchmark/test_classification/test_classifier.py
@@ -52,7 +52,7 @@ def test_load_model__ok_custom_head():
 
 def test_load_model__nok_custom_head():
     """
-    Unappy path for Classifier.load_model.
+    Unhappy path for Classifier.load_model.
     If a user decides to use his own model head, he just needs to make sure it is following the ClassificationModelProtocol.
     If this is not the case, raise an error.
     """

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -29,7 +29,7 @@ class Geneformer(HelicalRNAModel):
     - gf-12L-95M-i4096-CLcancer
     - gf-20L-95M-i4096
 
-    For a detailed explanation of the differences between these models and versions, please refer to the Geneformer model card: https://helical.readthedocs.io/en/latest/docs/Geneformer.html
+    For a detailed explanation of the differences between these models and versions, please refer to the Geneformer model card: https://helical.readthedocs.io/en/latest/model_cards/geneformer/
 
     Example
     -------


### PR DESCRIPTION
Link to the GeneFormer model card is broken. Adding the correct link. Also fix a few typos.