### PR TITLE
Fix n_counts estimation in geneformer_tokenizer when anndata.X is a dense matrix

### DIFF
--- a/helical/models/geneformer/geneformer_tokenizer.py
+++ b/helical/models/geneformer/geneformer_tokenizer.py
@@ -53,8 +53,7 @@ from collections import Counter
 import numpy as np
 import scipy.sparse as sp
 from datasets import Dataset
-from anndata import AnnData
-from numpy import ndarray
+from anndata._core.views import ArrayView
 import pandas as pd
 from tqdm import tqdm
 import scanpy as sc
@@ -451,7 +450,12 @@ class TranscriptomeTokenizer:
                 n_counts = adata[idx].obs["n_counts"].values[:, None]
             else:
                 # If 'n_counts' doesn't exist, calculate it as the sum of counts for each cell
-                n_counts = adata[idx, :].X.sum(axis=1)
+                if isinstance(adata.X, ArrayView):
+                    # If adata.X is an ArrayView the sum returns only
+                    # one dimension, while 2 are required for broadcasting below
+                    n_counts = adata[idx, :].X.sum(axis=1)[:, None]
+                else:
+                    n_counts = adata[idx, :].X.sum(axis=1)
 
             X_view0 = adata[idx, :].X
             X_view = X_view0[:, coding_miRNA_loc]


### PR DESCRIPTION
### Description
The X matrix containing the expression values in Anndata objects can be a sparse matrix or a dense matrix. For dataset using dense matrices to represent the data, we get a broadcasting error in [here](https://github.com/helicalAI/helical/blob/8b408d41179ecb00920d3900bf5c189f4150b7b7/helical/models/geneformer/geneformer_tokenizer.py#L458). This is because the `n_counts` objects (created [here](https://github.com/helicalAI/helical/blob/8b408d41179ecb00920d3900bf5c189f4150b7b7/helical/models/geneformer/geneformer_tokenizer.py#L454)) has only one dimension when using dense matrices, while it has 2 dimension when using sparse matrices (which is what we need). Currently this method properly handles only sparse matrices.

### Solution
Check whether anndata.X is a dense matrix (e.g., type ArrayView), and in this case expand with an extra dimension.