### PR TITLE
Helix-mRNA example typo

### DIFF
--- a/docs/model_cards/helix_mrna.md
+++ b/docs/model_cards/helix_mrna.md
@@ -101,7 +101,7 @@ import torch
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
-helix_mrna_config = HelimRNAConfig(batch_size=5, max_length=100, device=device)
+helix_mrna_config = HelixmRNAConfig(batch_size=5, max_length=100, device=device)
 helix_mrna = HelixmRNA(configurer=helix_mrna_config)
 
 rna_sequences = ["EACUEGGG", "EACUEGGG", "EACUEGGG", "EACUEGGG", "EACUEGGG"]

--- a/helical/models/helix_mrna/model.py
+++ b/helical/models/helix_mrna/model.py
@@ -30,7 +30,7 @@ class HelixmRNA(HelicalRNAModel):
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     
-    helix_mrna_config = HelimRNAConfig(batch_size=5, max_length=100, device=device)
+    helix_mrna_config = HelixmRNAConfig(batch_size=5, max_length=100, device=device)
     helix_mrna = HelixmRNA(configurer=helix_mrna_config)
     
     rna_sequences = ["EACUEGGG", "EACUEGGG", "EACUEGGG", "EACUEGGG", "EACUEGGG"]


### PR DESCRIPTION
- Typo in the example script shown in the docstrings and model card for Helix-mRNA raised in #183 