### PR TITLE
Installing dependencies in Evo-2 notebook

### DIFF
--- a/examples/notebooks/Evo-2.ipynb
+++ b/examples/notebooks/Evo-2.ipynb
@@ -45,7 +45,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install evaluate"
+    "!pip install evaluate\n",
+    "!pip install "helical[evo-2]@git+https://github.com/helicalAI/helical.git"
    ]
   },
   {


### PR DESCRIPTION
Hi,
(thanks for implementing Evo2 in helical - that was so fast!)

I've tried to run this notebook on Google Colab, and it complained that BioPython was not installed (when running one of the cells below)

If I understand the pyproject.toml file correctly, biopython and transformer-engine are optional dependencies, used only for Evo2.  Judging from the new installation instructions here https://github.com/helicalAI/helical/pull/201/files , it seems the pip install for helical/evo2 is the one I pasted here. 

I think it would be useful to mention this in the notebook, so users will not be confused by the missing biopython error.