### PR TITLE
fixed typo in README.md for helix-mRNA

### DIFF
--- a/helical/models/helix_mrna/README.md
+++ b/helical/models/helix_mrna/README.md
@@ -109,7 +109,7 @@ dataset = helix_mrna.process_data(rna_sequences)
 
 rna_embeddings = helix_mrna.get_embeddings(dataset)
 
-print("Helix-mRNA embeddings shape: ", embeddings.shape)
+print("Helix-mRNA embeddings shape: ", rna_embeddings.shape)
 ```
 
 **Example Fine-Tuning:**


### PR DESCRIPTION
Just a minor typo in this example.

(note: I'm trying Helix for this Kaggle competition https://www.kaggle.com/competitions/stanford-rna-3d-folding )