### PR TITLE
Fix transfomer-engine version in evo2 docker install

### DIFF
--- a/helical/models/evo_2/Dockerfile
+++ b/helical/models/evo_2/Dockerfile
@@ -17,7 +17,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 RUN pip install lightning wandb
 ENV CUDNN_PATH=/opt/conda/lib/python3.11/site-packages/nvidia/cudnn
 
-RUN pip install transformer-engine[pytorch]
+RUN pip install transformer-engine[pytorch]==1.13.0
 
 RUN git clone --recurse-submodules https://github.com/ArcInstitute/evo2.git
 RUN cd evo2 && pip install .


### PR DESCRIPTION
Fixed the version of `transformer-engine` in the EVO2 Docker installation.

When running EVO2 in a Docker container, errors occur as described in [issue #223](https://github.com/helicalAI/helical/issues/223). These are caused by the `transformer-engine` version not being pinned to 1.13.0, as it is in the pyproject.toml.