### PR TITLE
Stop helix-mrna from padding to model max length

### DIFF
--- a/helical/models/helix_mrna/model.py
+++ b/helical/models/helix_mrna/model.py
@@ -95,6 +95,7 @@ class HelixmRNA(HelicalRNAModel):
             sequences,
             return_tensors="pt",
             truncation=True,
+            padding="longest",
             max_length=self.config["input_size"],
             return_special_tokens_mask=True,
         )


### PR DESCRIPTION
The model previously padded to the max length specified in the initial config rather than the max length of the sequence in the dataset. If the default is left this results in sequences being padded to 12288 even if the inputs are of length 100 for example.