### PR TITLE
All hidden states correct accumulation

### DIFF
--- a/helical/models/helix_mrna/modeling_helix_mrna.py
+++ b/helical/models/helix_mrna/modeling_helix_mrna.py
@@ -1666,7 +1666,13 @@ class HelixmRNAPretrainedModel(HelixmRNAPreTrainedModel):
                     cache_position=cache_position,
                 )
 
-            hidden_states = layer_outputs[0]
+            if output_hidden_states:
+                all_hidden_states += (layer_outputs[0],)
+
+        hidden_states = self.norm_f(layer_outputs[0])
+
+        if output_hidden_states:
+            all_hidden_states = all_hidden_states + (hidden_states,)
 
             if output_attentions:
                 if layer_outputs[1] is not None:
@@ -1675,11 +1681,6 @@ class HelixmRNAPretrainedModel(HelixmRNAPreTrainedModel):
 
         if use_cache:
             cache_params.seqlen_offset += inputs_embeds.shape[1]
-
-        hidden_states = self.norm_f(hidden_states)
-
-        if output_hidden_states:
-            all_hidden_states += (hidden_states,)
 
         if not return_dict:
             return tuple(


### PR DESCRIPTION
- The helix model would only return the hidden states from the final layer if `output_hidden_states=True`
- This is corrected in the model code to behave correctly if this is desired
- This does not affect the functionality of the standard embedding flow on Helical