### PR TITLE
`anndata` 0.12 allowed in `pyproject.toml`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ license = {file = "LICENSE"}
 dependencies = [
     'requests>=2.32.3',
     'pandas==2.2.2',
-    'anndata==0.11',
+    'anndata>=0.11',
     'numpy==1.26.4',
     'scikit-learn>=1.5.0',
     'scipy==1.13.1',


### PR DESCRIPTION
Updated pyproject.toml to include anndata 0.12.