### PR TITLE
Address Different Size Attention Maps and Genes In Context

### DIFF
--- a/ci/tests/test_geneformer/test_geneformer_model.py
+++ b/ci/tests/test_geneformer/test_geneformer_model.py
@@ -163,6 +163,28 @@ class TestGeneformer:
             expected = np.array([[4, 4.333333, 4.666667, 4.333333, 4]])
             np.testing.assert_allclose(embeddings, expected, rtol=1e-4, atol=1e-4)
 
+    def test_get_embeddings_with_output_genes(
+        self, mock_data, mock_embeddings_v1, mocker
+    ):
+        config = GeneformerConfig(
+            model_name="gf-12L-30M-i2048", batch_size=5, emb_mode="cell"
+        )
+        geneformer = Geneformer(config)
+        mocker.patch.object(
+            geneformer.model, "forward", return_value=mock_embeddings_v1
+        )
+
+        dataset = geneformer.process_data(mock_data, gene_names="gene_symbols")
+        embeddings, genes = geneformer.get_embeddings(dataset, output_genes=True)
+
+        expected = np.array([[4, 4.333333, 4.666667, 4.333333, 4]])
+        np.testing.assert_allclose(embeddings, expected, rtol=1e-4, atol=1e-4)
+        assert set(genes).intersection(["ENSG00000187583", "ENSG00000187634", "ENSG00000188290"]) == {
+            "ENSG00000187583",
+            "ENSG00000187634",
+            "ENSG00000188290",
+        }
+
     @pytest.mark.parametrize("emb_mode", ["cell", "gene", "cls"])
     def test_get_embeddings_of_different_modes_v2(
         self, emb_mode, mock_data, mock_embeddings_v2, mocker

--- a/ci/tests/test_geneformer/test_geneformer_model.py
+++ b/ci/tests/test_geneformer/test_geneformer_model.py
@@ -179,11 +179,11 @@ class TestGeneformer:
 
         expected = np.array([[4, 4.333333, 4.666667, 4.333333, 4]])
         np.testing.assert_allclose(embeddings, expected, rtol=1e-4, atol=1e-4)
-        assert set(genes).intersection(["ENSG00000187583", "ENSG00000187634", "ENSG00000188290"]) == {
-            "ENSG00000187583",
-            "ENSG00000187634",
-            "ENSG00000188290",
-        }
+        for gene_list in genes:
+            assert len(gene_list) == 3
+            assert "ENSG00000187583" in gene_list
+            assert "ENSG00000187634" in gene_list
+            assert "ENSG00000188290" in gene_list
 
     @pytest.mark.parametrize("emb_mode", ["cell", "gene", "cls"])
     def test_get_embeddings_of_different_modes_v2(

--- a/ci/tests/test_scgpt/test_scgpt_model.py
+++ b/ci/tests/test_scgpt/test_scgpt_model.py
@@ -211,8 +211,9 @@ class TestSCGPTModel:
                 atol=1e-4,  # absolute tolerance
             )
             assert len(genes) == len(embeddings)
-            for gene in genes:
-                assert gene in ["SAMD11", "PLEKHN1", "HES4"]
+            for gene_list in genes:
+                for gene in gene_list:
+                    assert gene in ["SAMD11", "PLEKHN1", "HES4"]
 
     @pytest.mark.parametrize("emb_mode", ["cls", "cell"])
     def test_normalization_cell_and_cls(self, emb_mode):

--- a/examples/run_models/configs/scgpt_config.yaml
+++ b/examples/run_models/configs/scgpt_config.yaml
@@ -1,6 +1,6 @@
 pad_token: "<pad>"
 batch_size: 24
-emb_mode: "gene"
+emb_mode: "cell"
 fast_transformer: True
 nlayers: 12
 nheads: 8

--- a/examples/run_models/run_geneformer.py
+++ b/examples/run_models/run_geneformer.py
@@ -24,7 +24,7 @@ def run(cfg: DictConfig):
     ann_data = ad.read_h5ad("./yolksac_human.h5ad")
 
     dataset = geneformer.process_data(ann_data[:10, :100])
-    embeddings = geneformer.get_embeddings(dataset)
+    embeddings = geneformer.get_embeddings(dataset, output_genes=True)
 
     print(embeddings)
     embeddings, attention_weights = geneformer.get_embeddings(

--- a/examples/run_models/run_scgpt.py
+++ b/examples/run_models/run_scgpt.py
@@ -24,8 +24,8 @@ def run(cfg: DictConfig):
     ann_data = ad.read_h5ad("./yolksac_human.h5ad")
 
     data = scgpt.process_data(ann_data[:10])
-    embeddings = scgpt.get_embeddings(data, output_attentions=False)
-    print(embeddings)
+    embeddings, input_genes = scgpt.get_embeddings(data, output_genes=True)
+    print(embeddings, input_genes)
     embeddings, attn_weights = scgpt.get_embeddings(data, output_attentions=True)
 
     print(embeddings)

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -203,7 +203,7 @@ class Geneformer(HelicalRNAModel):
         return tokenized_dataset
 
     def get_embeddings(
-        self, dataset: Dataset, output_attentions: bool = False
+        self, dataset: Dataset, output_attentions: bool = False, output_genes: bool = False
     ) -> np.array:
         """Gets the gene embeddings from the Geneformer model
 
@@ -214,15 +214,21 @@ class Geneformer(HelicalRNAModel):
         output_attentions : bool, optional, default=False
             Whether to output attentions from the model. This is useful for debugging or analysis purposes.
             The attention maps are averaged across heads and use the same layer as the embeddings.
+        output_genes : bool, optional, default=False
+            Whether to output the genes corresponding to the embeddings.
 
         Returns
         -------
         np.array
             The gene embeddings in the form of a numpy array
-        np.array, optional
+        list, optional
             The attention weights from the model, if `output_attentions` is set to True.
             The shape of the attention weights is (batch_size, num_heads, seq_length, seq_length).
             If `output_attentions` is False, this will not be returned.
+        list, optional
+            The list of genes corresponding to the embeddings, if `output_genes` is set to True.
+            Each element in the list corresponds to the genes for each input in the dataset.
+            If `output_genes` is False, this will not be returned.
         """
         LOGGER.info(f"Started getting embeddings:")
         embeddings = get_embs(
@@ -238,6 +244,7 @@ class Geneformer(HelicalRNAModel):
             self.eos_present,
             self.device,
             output_attentions=output_attentions,
+            output_genes=output_genes,
         )
 
         LOGGER.info(f"Finished getting embeddings.")


### PR DESCRIPTION
- This addresses #244 
- For Geneformer, the attention matrices are now a list of numpy arrays to allow for variable size inputs
- For both Geneformer and scGPT, a flag to `output_genes` is now available which will cause `get_embeddings` to return a tuple including the a list of gene names per embedding. These gene names are the genes that were present in the context window during inference of the model.