### PR TITLE
Fix deprecation warning geneformer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,7 @@ jobs:
           sed -i 's/list(np.array(train_dataset.obs\[\\"LVL1\\"].tolist()))/list(np.array(train_dataset.obs\[\\"LVL1\\"].tolist()))[:100]/g' ./examples/notebooks/Cell-Type-Classification-Fine-Tuning.ipynb
           sed -i 's/list(np.array(test_dataset.obs\[\\"LVL1\\"].tolist()))/list(np.array(test_dataset.obs\[\\"LVL1\\"].tolist()))[:10]/g' ./examples/notebooks/Cell-Type-Classification-Fine-Tuning.ipynb
           rm ./examples/notebooks/Evo-2.ipynb
+          rm ./examples/notebooks/Geneformer-Series-Comparison.ipynb
 
       - name: Run Notebooks
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,6 @@ jobs:
           sed -i 's/list(np.array(train_dataset.obs\[\\"LVL1\\"].tolist()))/list(np.array(train_dataset.obs\[\\"LVL1\\"].tolist()))[:100]/g' ./examples/notebooks/Cell-Type-Classification-Fine-Tuning.ipynb
           sed -i 's/list(np.array(test_dataset.obs\[\\"LVL1\\"].tolist()))/list(np.array(test_dataset.obs\[\\"LVL1\\"].tolist()))[:10]/g' ./examples/notebooks/Cell-Type-Classification-Fine-Tuning.ipynb
           rm ./examples/notebooks/Evo-2.ipynb
-          rm ./examples/notebooks/Geneformer-Series-Comparison.ipynb
 
       - name: Run Notebooks
         run: |

--- a/ci/tests/test_geneformer/test_geneformer_model.py
+++ b/ci/tests/test_geneformer/test_geneformer_model.py
@@ -288,3 +288,24 @@ class TestGeneformer:
         geneformer = Geneformer(config)
 
         assert geneformer.layer_to_quant == emb_layer
+
+    @pytest.mark.parametrize(
+        "old_model_name,new_model_name",
+        [
+            ("gf-6L-30M-i2048", "gf-6L-10M-i2048"),
+            ("gf-12L-30M-i2048", "gf-12L-40M-i2048"),
+            ("gf-12L-95M-i4096", "gf-12L-38M-i4096"),
+            ("gf-12L-95M-i4096-CLcancer", "gf-12L-38M-i4096-CLcancer"),
+            ("gf-20L-95M-i4096", "gf-20L-151M-i4096"),
+        ],
+    )
+    def test_model_name_mapping(self, old_model_name, new_model_name, caplog):
+        with caplog.at_level("WARNING"):
+            config = GeneformerConfig(model_name=old_model_name)
+
+        assert config.config["model_name"] == new_model_name
+
+        assert any(
+            f"Model name {old_model_name} is deprecated" in message
+            for message in caplog.messages
+        ), f"No deprecation warning for {old_model_name}"

--- a/ci/tests/test_geneformer/test_geneformer_model.py
+++ b/ci/tests/test_geneformer/test_geneformer_model.py
@@ -300,8 +300,8 @@ class TestGeneformer:
         ],
     )
     def test_model_name_mapping(self, old_model_name, new_model_name, caplog):
-        with caplog.at_level("WARNING"):
-            config = GeneformerConfig(model_name=old_model_name)
+        caplog.set_level("WARNING")
+        config = GeneformerConfig(model_name=old_model_name)
 
         assert config.config["model_name"] == new_model_name
 

--- a/ci/tests/test_geneformer/test_geneformer_model.py
+++ b/ci/tests/test_geneformer/test_geneformer_model.py
@@ -299,13 +299,7 @@ class TestGeneformer:
             ("gf-20L-95M-i4096", "gf-20L-151M-i4096"),
         ],
     )
-    def test_model_name_mapping(self, old_model_name, new_model_name, caplog):
-        caplog.set_level("WARNING")
+    def test_model_name_mapping(self, old_model_name, new_model_name):
         config = GeneformerConfig(model_name=old_model_name)
 
         assert config.config["model_name"] == new_model_name
-
-        assert any(
-            f"Model name {old_model_name} is deprecated" in message
-            for message in caplog.messages
-        ), f"No deprecation warning for {old_model_name}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helical"
-version = "1.4.0"
+version = "1.4.1"
 authors = [
   { name="Helical Team", email="support@helical-ai.com" },
 ]


### PR DESCRIPTION
- We had no deprecation or aliasing for old geneformer model names. Added an alias and deprecation message for now so the change doesn't break other existing code.