### PR TITLE
Fix deprecation warning geneformer (#260)

### DIFF
--- a/ci/tests/test_geneformer/test_geneformer_model.py
+++ b/ci/tests/test_geneformer/test_geneformer_model.py
@@ -288,3 +288,18 @@ class TestGeneformer:
         geneformer = Geneformer(config)
 
         assert geneformer.layer_to_quant == emb_layer
+
+    @pytest.mark.parametrize(
+        "old_model_name,new_model_name",
+        [
+            ("gf-6L-30M-i2048", "gf-6L-10M-i2048"),
+            ("gf-12L-30M-i2048", "gf-12L-40M-i2048"),
+            ("gf-12L-95M-i4096", "gf-12L-38M-i4096"),
+            ("gf-12L-95M-i4096-CLcancer", "gf-12L-38M-i4096-CLcancer"),
+            ("gf-20L-95M-i4096", "gf-20L-151M-i4096"),
+        ],
+    )
+    def test_model_name_mapping(self, old_model_name, new_model_name):
+        config = GeneformerConfig(model_name=old_model_name)
+
+        assert config.config["model_name"] == new_model_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helical"
-version = "1.4.0"
+version = "1.4.1"
 authors = [
   { name="Helical Team", email="support@helical-ai.com" },
 ]


### PR DESCRIPTION
* Revert "Hot fix remove notebook from release run"

This reverts commit 52bba026f1cb6149cf7e6a7f57f1ee261a6c4769.

* Add aliasing and a deprecation message for old Geneformer models

* Update helical version for release

* fixup! Update helical version for release

* fixup! Add aliasing and a deprecation message for old Geneformer models

* Caplog not working