### PR TITLE
fix(docs): correct typo in documentation link sentence

### DIFF
--- a/examples/notebooks/Quick-Start-Tutorial.ipynb
+++ b/examples/notebooks/Quick-Start-Tutorial.ipynb
@@ -100,7 +100,7 @@
    "id": "bd26984f",
    "metadata": {},
    "source": [
-    "Unamiliar with anndata ? anndata is a Python package for handling annotated data matrices in memory and on disk, positioned between pandas and xarray. You can find thei docuemntation [here](https://anndata.readthedocs.io/)."
+    "Unamiliar with anndata ? anndata is a Python package for handling annotated data matrices in memory and on disk, positioned between pandas and xarray. You can find the documentation [here](https://anndata.readthedocs.io/)."
    ]
   },
   {


### PR DESCRIPTION
This pull request makes a minor documentation fix in the quick start tutorial notebook, correcting a typo in the sentence referring to the AnnData documentation:

- "thei docuemntation" → "the documentation"

