### PR TITLE
More ESM-2 embeddings

### DIFF
--- a/helical/models/transcriptformer/transcriptformer_config.py
+++ b/helical/models/transcriptformer/transcriptformer_config.py
@@ -129,6 +129,10 @@ class TranscriptFormerConfig:
                 "transcriptformer/tf_metazoa/vocabs/oryctolagus_cuniculus_gene.h5",
                 "transcriptformer/tf_metazoa/vocabs/spongilla_lacustris_gene.h5",
                 "transcriptformer/tf_metazoa/vocabs/homo_sapiens_gene.h5",
+                "transcriptformer/tf_metazoa/vocabs/canis_lupus_familiaris.h5",
+                "transcriptformer/tf_metazoa/vocabs/rattus_norvegicus.h5",
+                "transcriptformer/tf_metazoa/vocabs/sus_scrofa.h5",
+                "transcriptformer/tf_metazoa/vocabs/macaca_fascicularis.h5",
             ]
         elif model_name == "tf_exemplar":
             self.list_of_files_to_download = [


### PR DESCRIPTION
Added `esm2_t36_3B_UR50D` embedding paths to transcriptformer's config for the following species:
* [canis lupus familiaris](https://ftp.ensembl.org/pub/current/fasta/canis_lupus_familiaris/)
* [macaca fascicularis](https://ftp.ensembl.org/pub/current/fasta/macaca_fascicularis/)
* [rattus norvegicus](https://ftp.ensembl.org/pub/current/fasta/rattus_norvegicus/)
* [sus scrofa](https://ftp.ensembl.org/pub/current/fasta/sus_scrofa/)