### PR TITLE
Bug fix: TF surgery

### DIFF
--- a/ci/tests/test_transcriptformer/test_transcriptformer_model.py
+++ b/ci/tests/test_transcriptformer/test_transcriptformer_model.py
@@ -78,3 +78,30 @@ class TestTranscriptFormerPretainedEmbeddingList:
         # All genes from both embedding files should be present in the updated vocab
         for gene in self.GENES_FILE_1 + self.GENES_FILE_2:
             assert gene in model.gene_vocab
+
+    def test_special_token_indices_preserved_after_surgery(self, tmp_path):
+        path1 = str(tmp_path / "embeddings_1.h5")
+        _write_dummy_embedding_h5(path1, self.GENES_FILE_1 + self.GENES_FILE_2)
+
+        base_configurer = TranscriptFormerConfig(emb_mode="cell")
+        base_model = TranscriptFormer(base_configurer)
+        base_special_token_indices = {
+            token: idx
+            for token, idx in base_model.gene_vocab.items()
+            if token.startswith("[") or token == "unknown"
+        }
+
+        surg_configurer = TranscriptFormerConfig(
+            emb_mode="cell",
+            pretrained_embedding=path1,
+        )
+        surg_model = TranscriptFormer(surg_configurer)
+
+        # Every special token must retain its original index after surgery so that
+        # _pad_mask (which uses model.gene_vocab.pad_idx) stays consistent with
+        # the PAD token written by process_batch (which uses gene_vocab["[PAD]"]).
+        for token, orig_idx in base_special_token_indices.items():
+            assert surg_model.gene_vocab[token] == orig_idx, (
+                f"Special token '{token}' index changed after surgery: "
+                f"expected {orig_idx}, got {surg_model.gene_vocab[token]}"
+            )

--- a/helical/models/transcriptformer/model_dir/embedding_surgery.py
+++ b/helical/models/transcriptformer/model_dir/embedding_surgery.py
@@ -47,19 +47,31 @@ def change_embedding_layer(
         [token for token in special_tokens if token not in old_special_tokens],
     )
 
-    # Concatenate the old special token embeddings with the new embeddings
+    # Build a special-token embedding matrix that preserves the original indices.
+    # The training vocab may assign special tokens to indices that differ from
+    # the order they appear in the SPECIAL_TOKENS list, so we must place each
+    # token's embedding at its original row rather than re-numbering them.
+    n_special = len(old_special_tokens)
+    special_emb_matrix = torch.zeros(
+        n_special, old_special_token_embeddings.shape[1], device="cuda"
+    )
+    for i, token in enumerate(old_special_tokens):
+        orig_idx = model.gene_vocab.vocab_dict[token]
+        special_emb_matrix[orig_idx] = old_special_token_embeddings[i]
+
+    # Concatenate the (correctly ordered) special token embeddings with the new gene embeddings
     new_embedding_matrix = torch.cat(
-        [old_special_token_embeddings, torch.Tensor(new_embedding_matrix).to("cuda")],
+        [special_emb_matrix, torch.Tensor(new_embedding_matrix).to("cuda")],
         dim=0,
     )
 
     # Update the vocab indices of the model
     gene_vocab = {
-        gene: idx + len(old_special_tokens) for gene, idx in gene_vocab.items()
+        gene: idx + n_special for gene, idx in gene_vocab.items()
     }
 
-    # Update the gene_vocab with the special tokens
-    gene_vocab.update({token: idx for idx, token in enumerate(old_special_tokens)})
+    # Restore special tokens at their original indices from the training vocab
+    gene_vocab.update({token: model.gene_vocab.vocab_dict[token] for token in old_special_tokens})
 
     # Create a new embedding layer
     new_embedding = torch.nn.Embedding(
@@ -80,5 +92,6 @@ def change_embedding_layer(
     # Update the gene_vocab
     model.gene_vocab.vocab_dict = gene_vocab
     model.gene_vocab.embedding_matrix = new_embedding_matrix
+    model.token_to_gene_dict = {v: k for k, v in gene_vocab.items()}
 
     return model, gene_vocab


### PR DESCRIPTION
Current implementation permutes indices of special tokens:
```
[START]: 2 -> 1
[END]: 3 -> 2
[RD]: 4 -> 3
[CELL]: 5 -> 4
[PAD]: 1 -> 5
[MASK]: 6 -> 6
```
This fix makes sure we preserve the indices
of the special tokens when performing vocabulary surgery.