### PR TITLE
Bumping transformers version to 4.53.0 to fix vulnerabilities

### DIFF
--- a/ci/tests/test_helix_mrna/test_helix_mrna_model.py
+++ b/ci/tests/test_helix_mrna/test_helix_mrna_model.py
@@ -12,6 +12,17 @@ class TestHelixmRNAModel:
         return HelixmRNA(configurer=config)
 
     @pytest.fixture
+    def helixmRNA_eager(self):
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        config = HelixmRNAConfig(
+            batch_size=1,
+            device=self.device,
+            max_length=100,
+            output_attentions=True,
+        )
+        return HelixmRNA(configurer=config)
+
+    @pytest.fixture
     def mock_data(self, helixmRNA):
         input_sequences = [
             "AAAA",
@@ -42,6 +53,34 @@ class TestHelixmRNAModel:
         assert (
             embeddings is not None
         ), f"Embeddings should not be None for sequence: {mock_data}"
+
+    def test_get_embeddings_output_attentions_requires_eager_config(
+        self, mock_data, helixmRNA
+    ):
+        with pytest.raises(
+            ValueError,
+            match=r"output_attentions=True requires the model to be loaded with eager",
+        ):
+            helixmRNA.get_embeddings(mock_data, output_attentions=True)
+
+    def test_get_embeddings_output_attentions_returns_attention_tensors(
+        self, helixmRNA_eager
+    ):
+        sequences = ["EACUEGG", "EACUEGG"]
+        dataset = helixmRNA_eager.process_data(sequences)
+
+        result = helixmRNA_eager.get_embeddings(dataset, output_attentions=True)
+
+        assert isinstance(result, tuple), "Expected tuple when output_attentions=True"
+        assert len(result) == 2
+        embeddings, attentions = result
+        assert isinstance(attentions, list)
+        assert len(attentions) >= 1
+        for attn in attentions:
+            assert attn.ndim == 4, (
+                f"Expected attention shape (batch, heads, seq, seq); "
+                f"got shape {attn.shape}"
+            )
 
     @pytest.mark.parametrize(
         "data, raise_exception",

--- a/examples/notebooks/Hyena-DNA-Inference.ipynb
+++ b/examples/notebooks/Hyena-DNA-Inference.ipynb
@@ -100,16 +100,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Filter: 100%|██████████| 461850/461850 [00:00<00:00, 477649.20 examples/s]\n",
-      "Filter: 100%|██████████| 48797/48797 [00:00<00:00, 492263.67 examples/s]\n"
+      "Filter: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 461850/461850 [00:00<00:00, 477649.20 examples/s]\n",
+      "Filter: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 48797/48797 [00:00<00:00, 492263.67 examples/s]\n"
      ]
     }
    ],
    "source": [
-    "from datasets import load_dataset\n",
-    "label = \"promoter_tata\"\n",
-    "\n",
-    "dataset = load_dataset(\"InstaDeepAI/nucleotide_transformer_downstream_tasks\",  trust_remote_code=True).filter(lambda x: x[\"task\"] == \"promoter_tata\")"
+    "from datasets import load_dataset\nlabel = \"promoter_tata\"\n\ndataset = load_dataset(\"InstaDeepAI/nucleotide_transformer_downstream_tasks_revised\", \"promoter_tata\")"
    ]
   },
   {
@@ -209,7 +206,7 @@
      "text": [
       "INFO:helical.models.hyena_dna.model:Succesfully prepared the HyenaDNA Dataset.\n",
       "INFO:helical.models.hyena_dna.model:Started getting embeddings:\n",
-      "Getting embeddings: 100%|██████████| 1102/1102 [00:03<00:00, 337.42it/s]\n",
+      "Getting embeddings: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1102/1102 [00:03<00:00, 337.42it/s]\n",
       "INFO:helical.models.hyena_dna.model:Finished getting embeddings.\n"
      ]
     }
@@ -452,7 +449,7 @@
       "INFO:helical.models.hyena_dna.model:Processing data for HyenaDNA.\n",
       "INFO:helical.models.hyena_dna.model:Succesfully prepared the HyenaDNA Dataset.\n",
       "INFO:helical.models.hyena_dna.model:Started getting embeddings:\n",
-      "Getting embeddings: 100%|██████████| 125/125 [00:00<00:00, 439.64it/s]\n",
+      "Getting embeddings: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 125/125 [00:00<00:00, 439.64it/s]\n",
       "INFO:helical.models.hyena_dna.model:Finished getting embeddings.\n"
      ]
     }
@@ -683,7 +680,7 @@
        "\n",
        "#sk-container-id-1 label.sk-toggleable__label-arrow:before {\n",
        "  /* Arrow on the left of the label */\n",
-       "  content: \"▸\";\n",
+       "  content: \"\u25b8\";\n",
        "  float: left;\n",
        "  margin-right: 0.25em;\n",
        "  color: var(--sklearn-color-icon);\n",
@@ -728,7 +725,7 @@
        "}\n",
        "\n",
        "#sk-container-id-1 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {\n",
-       "  content: \"▾\";\n",
+       "  content: \"\u25be\";\n",
        "}\n",
        "\n",
        "/* Pipeline/ColumnTransformer-specific style */\n",

--- a/examples/notebooks/HyenaDNA-Fine-Tuning.ipynb
+++ b/examples/notebooks/HyenaDNA-Fine-Tuning.ipynb
@@ -95,11 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "label = \"promoter_tata\"\n",
-    "\n",
-    "dataset = load_dataset(\"InstaDeepAI/nucleotide_transformer_downstream_tasks\",  trust_remote_code=True).filter(lambda x: x[\"task\"] == \"promoter_tata\")\n",
-    "dataset_train = dataset[\"train\"]\n",
-    "dataset_test = dataset[\"test\"]"
+    "label = \"promoter_tata\"\n\ndataset = load_dataset(\"InstaDeepAI/nucleotide_transformer_downstream_tasks_revised\", \"promoter_tata\")\ndataset_train = dataset[\"train\"]\ndataset_test = dataset[\"test\"]"
    ]
   },
   {
@@ -184,8 +180,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processing sequences: 100%|██████████| 5062/5062 [00:00<00:00, 10775.16it/s]\n",
-      "Processing sequences: 100%|██████████| 212/212 [00:00<00:00, 9641.03it/s]\n"
+      "Processing sequences: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 5062/5062 [00:00<00:00, 10775.16it/s]\n",
+      "Processing sequences: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 212/212 [00:00<00:00, 9641.03it/s]\n"
      ]
     }
    ],
@@ -217,26 +213,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Fine-Tuning: epoch 1/10: 100%|██████████| 507/507 [00:02<00:00, 191.25it/s, loss=0.654]\n",
-      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 729.64it/s, val_loss=0.602]\n",
-      "Fine-Tuning: epoch 2/10: 100%|██████████| 507/507 [00:02<00:00, 213.34it/s, loss=0.441]\n",
-      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 717.45it/s, val_loss=0.796]\n",
-      "Fine-Tuning: epoch 3/10: 100%|██████████| 507/507 [00:02<00:00, 211.52it/s, loss=0.453]\n",
-      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 716.82it/s, val_loss=0.597]\n",
-      "Fine-Tuning: epoch 4/10: 100%|██████████| 507/507 [00:02<00:00, 206.29it/s, loss=0.444]\n",
-      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 730.15it/s, val_loss=0.492]\n",
-      "Fine-Tuning: epoch 5/10: 100%|██████████| 507/507 [00:02<00:00, 232.99it/s, loss=0.439]\n",
-      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 724.66it/s, val_loss=0.424]\n",
-      "Fine-Tuning: epoch 6/10: 100%|██████████| 507/507 [00:01<00:00, 256.32it/s, loss=0.438]\n",
-      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 724.62it/s, val_loss=0.382]\n",
-      "Fine-Tuning: epoch 7/10: 100%|██████████| 507/507 [00:01<00:00, 258.73it/s, loss=0.436]\n",
-      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 715.60it/s, val_loss=0.351]\n",
-      "Fine-Tuning: epoch 8/10: 100%|██████████| 507/507 [00:02<00:00, 233.66it/s, loss=0.434]\n",
-      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 709.78it/s, val_loss=0.336]\n",
-      "Fine-Tuning: epoch 9/10: 100%|██████████| 507/507 [00:02<00:00, 240.10it/s, loss=0.432]\n",
-      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 714.25it/s, val_loss=0.328]\n",
-      "Fine-Tuning: epoch 10/10: 100%|██████████| 507/507 [00:02<00:00, 234.96it/s, loss=0.428]\n",
-      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 716.93it/s, val_loss=0.324]\n"
+      "Fine-Tuning: epoch 1/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 191.25it/s, loss=0.654]\n",
+      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 729.64it/s, val_loss=0.602]\n",
+      "Fine-Tuning: epoch 2/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 213.34it/s, loss=0.441]\n",
+      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 717.45it/s, val_loss=0.796]\n",
+      "Fine-Tuning: epoch 3/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 211.52it/s, loss=0.453]\n",
+      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 716.82it/s, val_loss=0.597]\n",
+      "Fine-Tuning: epoch 4/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 206.29it/s, loss=0.444]\n",
+      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 730.15it/s, val_loss=0.492]\n",
+      "Fine-Tuning: epoch 5/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 232.99it/s, loss=0.439]\n",
+      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 724.66it/s, val_loss=0.424]\n",
+      "Fine-Tuning: epoch 6/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:01<00:00, 256.32it/s, loss=0.438]\n",
+      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 724.62it/s, val_loss=0.382]\n",
+      "Fine-Tuning: epoch 7/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:01<00:00, 258.73it/s, loss=0.436]\n",
+      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 715.60it/s, val_loss=0.351]\n",
+      "Fine-Tuning: epoch 8/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 233.66it/s, loss=0.434]\n",
+      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 709.78it/s, val_loss=0.336]\n",
+      "Fine-Tuning: epoch 9/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 240.10it/s, loss=0.432]\n",
+      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 714.25it/s, val_loss=0.328]\n",
+      "Fine-Tuning: epoch 10/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 234.96it/s, loss=0.428]\n",
+      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 716.93it/s, val_loss=0.324]\n"
      ]
     }
    ],
@@ -267,7 +263,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 22/22 [00:00<00:00, 782.08it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 782.08it/s]\n"
      ]
     }
    ],

--- a/examples/run_models/configs/geneformer_attention_config.yaml
+++ b/examples/run_models/configs/geneformer_attention_config.yaml
@@ -3,4 +3,4 @@ batch_size: 24
 emb_layer: -1
 emb_mode: "cell"
 device: "cpu"
-output_attentions: false
+output_attentions: true

--- a/examples/run_models/configs/geneformer_config.yaml
+++ b/examples/run_models/configs/geneformer_config.yaml
@@ -3,3 +3,4 @@ batch_size: 24
 emb_layer: -1
 emb_mode: "cell"
 device: "cpu"
+output_attentions: true

--- a/examples/run_models/run_geneformer.py
+++ b/examples/run_models/run_geneformer.py
@@ -30,12 +30,6 @@ def run(cfg: DictConfig):
     embeddings = geneformer.get_embeddings(dataset, output_genes=True)
 
     print(embeddings)
-    embeddings, attention_weights = geneformer.get_embeddings(
-        dataset, output_attentions=True
-    )
-
-    print(embeddings)
-    print(attention_weights)
 
 
 if __name__ == "__main__":

--- a/examples/run_models/run_geneformer_attention.py
+++ b/examples/run_models/run_geneformer_attention.py
@@ -1,0 +1,28 @@
+from helical.models.geneformer import Geneformer, GeneformerConfig
+import hydra
+from omegaconf import DictConfig
+import anndata as ad
+
+
+@hydra.main(
+    version_base=None,
+    config_path="configs",
+    config_name="geneformer_attention_config",
+)
+def run(cfg: DictConfig):
+    geneformer_config = GeneformerConfig(**cfg)
+    geneformer = Geneformer(configurer=geneformer_config)
+
+    ann_data = ad.read_h5ad("./yolksac_human.h5ad")
+
+    dataset = geneformer.process_data(ann_data[:10, :100])
+    embeddings, attention_weights = geneformer.get_embeddings(
+        dataset, output_attentions=True
+    )
+
+    print(embeddings)
+    print(attention_weights)
+
+
+if __name__ == "__main__":
+    run()

--- a/helical/__init__.py
+++ b/helical/__init__.py
@@ -1,6 +1,20 @@
 import os
 import logging
 
+# Compatibility shim for mamba_ssm with transformers >= 4.53.0.
+# mamba_ssm.utils.generation still imports the removed GreedySearchDecoderOnlyOutput
+# and SampleDecoderOnlyOutput names; patch them back as aliases before any model
+# (Caduceus, HelixmRNA) triggers the mamba_ssm import.
+import transformers.generation as _tg
+
+if not hasattr(_tg, "GreedySearchDecoderOnlyOutput"):
+    from transformers.generation import GenerateDecoderOnlyOutput as _GDO
+
+    _tg.GreedySearchDecoderOnlyOutput = _GDO
+    _tg.SampleDecoderOnlyOutput = _GDO
+    del _GDO
+del _tg
+
 logging.captureWarnings(True)
 
 logger = logging.getLogger()

--- a/helical/__init__.py
+++ b/helical/__init__.py
@@ -1,20 +1,6 @@
 import os
 import logging
 
-# Compatibility shim for mamba_ssm with transformers >= 4.53.0.
-# mamba_ssm.utils.generation still imports the removed GreedySearchDecoderOnlyOutput
-# and SampleDecoderOnlyOutput names; patch them back as aliases before any model
-# (Caduceus, HelixmRNA) triggers the mamba_ssm import.
-import transformers.generation as _tg
-
-if not hasattr(_tg, "GreedySearchDecoderOnlyOutput"):
-    from transformers.generation import GenerateDecoderOnlyOutput as _GDO
-
-    _tg.GreedySearchDecoderOnlyOutput = _GDO
-    _tg.SampleDecoderOnlyOutput = _GDO
-    del _GDO
-del _tg
-
 logging.captureWarnings(True)
 
 logger = logging.getLogger()

--- a/helical/models/__init__.py
+++ b/helical/models/__init__.py
@@ -1,1 +1,13 @@
+# mamba_ssm (used by Caduceus and HelixmRNA) still imports the greedy/sample decoder
+# output names that transformers deleted; re-alias them here before any model loads.
+import transformers.generation as _tg
+
+if not hasattr(_tg, "GreedySearchDecoderOnlyOutput"):
+    from transformers.generation import GenerateDecoderOnlyOutput as _GDO
+
+    _tg.GreedySearchDecoderOnlyOutput = _GDO
+    _tg.SampleDecoderOnlyOutput = _GDO
+    del _GDO
+del _tg
+
 from .fine_tune.fine_tuning_heads import ClassificationHead, RegressionHead

--- a/helical/models/base_models.py
+++ b/helical/models/base_models.py
@@ -296,12 +296,27 @@ class HelicalBaseFineTuningModel(torch.nn.Module):
         """
         Load the model from a file.
 
+        Accepts both current state-dict checkpoints and legacy pickle checkpoints
+        (saved with the old ``torch.save(model, path)`` API).  The secure state-dict
+        load is attempted first; on failure we fall back to unpickling the legacy
+        full-model object and extracting its state dict.
+
         Parameters
         ----------
         path : str
             The path to load the model from.
         """
-        self.model.load_state_dict(torch.load(path, weights_only=True))
+        try:
+            state_dict = torch.load(path, weights_only=True)
+        except Exception:
+            LOGGER.warning(
+                f"State-dict load failed for {path}; "
+                f"attempting to load as a legacy pickle checkpoint."
+            )
+            legacy = torch.load(path, weights_only=False)
+            state_dict = legacy.state_dict() if not isinstance(legacy, dict) else legacy
+
+        self.model.load_state_dict(state_dict)
         self.model.eval()
         self.fine_tuning_head.eval()
         LOGGER.info(f"Model loaded from {path}")

--- a/helical/models/base_models.py
+++ b/helical/models/base_models.py
@@ -289,7 +289,7 @@ class HelicalBaseFineTuningModel(torch.nn.Module):
         path : str
             The path to save the model to.
         """
-        torch.save(self.model, path)
+        torch.save(self.model.state_dict(), path)
         LOGGER.info(f"Model saved to {path}")
 
     def load_model(self, path: str):
@@ -301,7 +301,7 @@ class HelicalBaseFineTuningModel(torch.nn.Module):
         path : str
             The path to load the model from.
         """
-        self.model = torch.load(path, weights_only=False)
+        self.model.load_state_dict(torch.load(path, weights_only=True))
         self.model.eval()
         self.fine_tuning_head.eval()
         LOGGER.info(f"Model loaded from {path}")

--- a/helical/models/caduceus/modeling_caduceus.py
+++ b/helical/models/caduceus/modeling_caduceus.py
@@ -312,8 +312,7 @@ class CaduceusPreTrainedModel(PreTrainedModel):
     base_model_prefix = "caduceus"
     supports_gradient_checkpointing = False
     _no_split_modules = ["BiMambaWrapper"]
-    # transformers >= 4.53.0 calls all_tied_weights_keys in mark_tied_weights_as_initialized;
-    # Caduceus handles weight tying internally so we declare no HF-managed tied weights.
+    # Caduceus handles weight tying internally (bidirectional_weight_tie), not via HF.
     all_tied_weights_keys = {}
 
     def _init_weights(

--- a/helical/models/caduceus/modeling_caduceus.py
+++ b/helical/models/caduceus/modeling_caduceus.py
@@ -312,6 +312,9 @@ class CaduceusPreTrainedModel(PreTrainedModel):
     base_model_prefix = "caduceus"
     supports_gradient_checkpointing = False
     _no_split_modules = ["BiMambaWrapper"]
+    # transformers >= 4.53.0 calls all_tied_weights_keys in mark_tied_weights_as_initialized;
+    # Caduceus handles weight tying internally so we declare no HF-managed tied weights.
+    all_tied_weights_keys = {}
 
     def _init_weights(
         self,

--- a/helical/models/caduceus/pretrained_config.py
+++ b/helical/models/caduceus/pretrained_config.py
@@ -13,6 +13,8 @@ class CaduceusPretrainedConfig(PretrainedConfig):
 
     This config is used to initialise the Caduceus pretrained model.
 
+    model_type is required by transformers >= 4.53.0 for proper from_pretrained handling.
+
     Parameters
     ----------
     d_model : int, optional, default=2560

--- a/helical/models/caduceus/pretrained_config.py
+++ b/helical/models/caduceus/pretrained_config.py
@@ -13,8 +13,6 @@ class CaduceusPretrainedConfig(PretrainedConfig):
 
     This config is used to initialise the Caduceus pretrained model.
 
-    model_type is required by transformers >= 4.53.0 for proper from_pretrained handling.
-
     Parameters
     ----------
     d_model : int, optional, default=2560
@@ -48,6 +46,8 @@ class CaduceusPretrainedConfig(PretrainedConfig):
     complement_map : Optional[dict], optional, default=None
         The complement map.
     """
+
+    model_type = "caduceus"
 
     def __init__(
         self,

--- a/helical/models/geneformer/geneformer_config.py
+++ b/helical/models/geneformer/geneformer_config.py
@@ -36,6 +36,10 @@ class GeneformerConfig:
         The device to use. Either use "cuda" or "cpu".
     nproc: int, optional, default=1
         Number of processes to use for data processing.
+    output_attentions : bool, optional, default=False
+        Whether to enable attention weight outputs. When True, forces eager attention (SDPA does not
+        support returning attention weights in transformers >= 4.53). Note: eager attention materialises
+        the full O(seq²) attention matrix and may cause OOM for long sequences or large batches.
     custom_attr_name_dict : dict, optional, default=None
         A dictionary that contains the names of the custom attributes to be added to the dataset.
         The keys of the dictionary are the names of the custom attributes, and the values are the names of the columns in adata.obs.
@@ -73,6 +77,7 @@ class GeneformerConfig:
         emb_mode: Literal["cls", "cell", "gene"] = "cell",
         device: Literal["cpu", "cuda"] = "cpu",
         nproc: int = 1,
+        output_attentions: bool = False,
         custom_attr_name_dict: Optional[dict] = None,
     ):
 
@@ -212,5 +217,6 @@ class GeneformerConfig:
             "special_token": self.model_map[model_name]["special_token"],
             "embsize": self.model_map[model_name]["embsize"],
             "nproc": nproc,
+            "output_attentions": output_attentions,
             "custom_attr_name_dict": custom_attr_name_dict,
         }

--- a/helical/models/geneformer/geneformer_config.py
+++ b/helical/models/geneformer/geneformer_config.py
@@ -32,14 +32,16 @@ class GeneformerConfig:
         The embedding mode to use. "cls" is only available for Geneformer v2 models, returning the embeddings of the cls token.
         For cell level embeddings, a mean across all embeddings excluding the cls token is returned.
         For gene level embeddings, each gene token embedding is returned along with the corresponding ensembl ID.
-    device : Literal["cpu", "cuda"], optional, default="cpu"
-        The device to use. Either use "cuda" or "cpu".
+    device : str, optional, default="cpu"
+        The device to use. Accepts any string torch.device accepts, e.g. "cpu",
+        "cuda", "cuda:0".
     nproc: int, optional, default=1
         Number of processes to use for data processing.
     output_attentions : bool, optional, default=False
-        Whether to enable attention weight outputs. When True, forces eager attention (SDPA does not
-        support returning attention weights in transformers >= 4.53). Note: eager attention materialises
-        the full O(seq²) attention matrix and may cause OOM for long sequences or large batches.
+        Whether to return attention weights from get_embeddings. Must be set at construction time:
+        True forces eager attention (required for attention output; flash_attention_2 and sdpa do
+        not support it), False uses flash_attention_2 when available, else sdpa. Note: eager
+        attention materialises the full O(seq²) matrix and may OOM on long sequences or large batches.
     custom_attr_name_dict : dict, optional, default=None
         A dictionary that contains the names of the custom attributes to be added to the dataset.
         The keys of the dictionary are the names of the custom attributes, and the values are the names of the columns in adata.obs.
@@ -75,7 +77,7 @@ class GeneformerConfig:
         batch_size: int = 24,
         emb_layer: int = -1,
         emb_mode: Literal["cls", "cell", "gene"] = "cell",
-        device: Literal["cpu", "cuda"] = "cpu",
+        device: str = "cpu",
         nproc: int = 1,
         output_attentions: bool = False,
         custom_attr_name_dict: Optional[dict] = None,

--- a/helical/models/geneformer/geneformer_utils.py
+++ b/helical/models/geneformer/geneformer_utils.py
@@ -10,6 +10,7 @@ from tqdm.auto import trange
 import re
 import torch
 from transformers import BertForMaskedLM
+from helical.utils.attn_backend import select_attn_backend
 import pandas as pd
 import numpy as np
 
@@ -196,10 +197,10 @@ def get_embs(
                 output_attentions=output_attentions,
             )
 
-            embs_i = outputs.hidden_states[layer_to_quant]
+            embs_i = outputs.hidden_states[layer_to_quant].float()
             # attention of size (batch_size, num_heads, sequence_length, sequence_length)
             if output_attentions:
-                attn_i = outputs.attentions[layer_to_quant]
+                attn_i = outputs.attentions[layer_to_quant].float()
                 # attn_i = torch.mean(attn_i, dim=1).cpu().numpy()  # average over heads
                 attn_list.extend(attn_i.cpu().numpy())
 
@@ -263,15 +264,24 @@ def get_model_input_size(model):
 
 
 def load_model(model_type, model_directory, device, output_attentions=False):
-    if model_type == "Pretrained":
-        attn_impl = "eager" if output_attentions else "sdpa"
-        model = BertForMaskedLM.from_pretrained(
-            model_directory,
-            output_hidden_states=True,
-            output_attentions=False,
-            attn_implementation=attn_impl,
+    if model_type != "Pretrained":
+        raise ValueError(
+            f"Unsupported model_type: {model_type!r}. Only 'Pretrained' is supported."
         )
-    # put the model in eval mode for fwd pass and load onto the GPU if available
+    attn_impl, model_dtype = select_attn_backend(
+        device, output_attentions=output_attentions
+    )
+    if attn_impl == "flash_attention_2":
+        logger.warning(
+            "Loading Geneformer in bfloat16 for flash_attention_2 compatibility."
+        )
+    model = BertForMaskedLM.from_pretrained(
+        model_directory,
+        output_hidden_states=True,
+        output_attentions=False,
+        attn_implementation=attn_impl,
+        torch_dtype=model_dtype,
+    )
     model.eval()
     model = model.to(device)
     return model

--- a/helical/models/geneformer/geneformer_utils.py
+++ b/helical/models/geneformer/geneformer_utils.py
@@ -262,10 +262,14 @@ def get_model_input_size(model):
     return int(re.split("\(|,", str(model.bert.embeddings.position_embeddings))[1])
 
 
-def load_model(model_type, model_directory, device):
+def load_model(model_type, model_directory, device, output_attentions=False):
     if model_type == "Pretrained":
+        attn_impl = "eager" if output_attentions else "sdpa"
         model = BertForMaskedLM.from_pretrained(
-            model_directory, output_hidden_states=True, output_attentions=False
+            model_directory,
+            output_hidden_states=True,
+            output_attentions=False,
+            attn_implementation=attn_impl,
         )
     # put the model in eval mode for fwd pass and load onto the GPU if available
     model.eval()

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 from anndata import AnnData
 from helical.utils.downloader import Downloader
+from helical.utils.attn_backend import select_attn_backend
 from transformers import BertForMaskedLM
 from helical.models.geneformer.geneformer_utils import get_embs, quant_layers
 from helical.models.geneformer.geneformer_tokenizer import TranscriptomeTokenizer
@@ -88,12 +89,20 @@ class Geneformer(HelicalRNAModel):
         for file in self.configurer.list_of_files_to_download:
             downloader.download_via_name(file)
 
-        attn_impl = "eager" if self.config["output_attentions"] else "sdpa"
+        attn_impl, model_dtype = select_attn_backend(
+            self.device,
+            output_attentions=self.config.get("output_attentions", False),
+        )
+        if attn_impl == "flash_attention_2":
+            LOGGER.warning(
+                "Loading Geneformer in bfloat16 for flash_attention_2 compatibility."
+            )
         self.model = BertForMaskedLM.from_pretrained(
             self.files_config["model_files_dir"],
             output_hidden_states=True,
             output_attentions=False,
             attn_implementation=attn_impl,
+            torch_dtype=model_dtype,
         )
         self.model.eval()
         self.model = self.model.to(self.device)
@@ -236,10 +245,10 @@ class Geneformer(HelicalRNAModel):
             Each element in the list corresponds to the genes for each input in the dataset.
             If `output_genes` is False, this will not be returned.
         """
-        if output_attentions and not self.config["output_attentions"]:
+        if output_attentions and not self.config.get("output_attentions", False):
             raise ValueError(
                 "output_attentions=True requires the model to be loaded with eager attention. "
-                "Set output_attentions=True in GeneformerConfig."
+                "Set output_attentions=True in GeneformerConfig before instantiating the model."
             )
         LOGGER.info(f"Started getting embeddings:")
         embeddings = get_embs(

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -88,10 +88,12 @@ class Geneformer(HelicalRNAModel):
         for file in self.configurer.list_of_files_to_download:
             downloader.download_via_name(file)
 
+        attn_impl = "eager" if self.config["output_attentions"] else "sdpa"
         self.model = BertForMaskedLM.from_pretrained(
             self.files_config["model_files_dir"],
             output_hidden_states=True,
             output_attentions=False,
+            attn_implementation=attn_impl,
         )
         self.model.eval()
         self.model = self.model.to(self.device)
@@ -234,6 +236,11 @@ class Geneformer(HelicalRNAModel):
             Each element in the list corresponds to the genes for each input in the dataset.
             If `output_genes` is False, this will not be returned.
         """
+        if output_attentions and not self.config["output_attentions"]:
+            raise ValueError(
+                "output_attentions=True requires the model to be loaded with eager attention. "
+                "Set output_attentions=True in GeneformerConfig."
+            )
         LOGGER.info(f"Started getting embeddings:")
         embeddings = get_embs(
             self.model,

--- a/helical/models/helix_mrna/helix_mrna_config.py
+++ b/helical/models/helix_mrna/helix_mrna_config.py
@@ -16,6 +16,11 @@ class HelixmRNAConfig:
         The maximum length of the input sequence.
     nproc: int, optional, default=1
         Number of processes to use for data processing.
+    output_attentions : bool, optional, default=False
+        Whether to enable attention weight outputs from the hybrid attention layers.
+        When True, forces eager attention (flash_attention_2 and SDPA do not support
+        returning attention weights). Note: eager attention materialises the full O(seq²)
+        attention matrix and may cause OOM for long sequences.
     """
 
     def __init__(
@@ -24,6 +29,7 @@ class HelixmRNAConfig:
         device: Literal["cpu", "cuda"] = "cpu",
         max_length: int = 12288,
         nproc: int = 1,
+        output_attentions: bool = False,
     ):
 
         model_name: Literal["helical-ai/Helix-mRNA"] = "helical-ai/Helix-mRNA"
@@ -34,4 +40,5 @@ class HelixmRNAConfig:
             "batch_size": batch_size,
             "device": device,
             "nproc": nproc,
+            "output_attentions": output_attentions,
         }

--- a/helical/models/helix_mrna/helix_mrna_config.py
+++ b/helical/models/helix_mrna/helix_mrna_config.py
@@ -10,23 +10,25 @@ class HelixmRNAConfig:
     ----------
     batch_size : int, optional, default=10
         The batch size
-    device : Literal["cpu", "cuda"], optional, default="cpu"
-        The device to use. Either use "cuda" or "cpu".
+    device : str, optional, default="cpu"
+        The device to use. Accepts any string torch.device accepts, e.g. "cpu",
+        "cuda", "cuda:0".
     max_length : int, optional, default=12288
         The maximum length of the input sequence.
     nproc: int, optional, default=1
         Number of processes to use for data processing.
     output_attentions : bool, optional, default=False
-        Whether to enable attention weight outputs from the hybrid attention layers.
-        When True, forces eager attention (flash_attention_2 and SDPA do not support
-        returning attention weights). Note: eager attention materialises the full O(seq²)
-        attention matrix and may cause OOM for long sequences.
+        Whether to return attention weights from get_embeddings. Must be set at
+        construction time: True forces eager attention (required for attention
+        output), False uses flash_attention_2 when available, else sdpa. Note:
+        eager attention materialises the full O(seq²) matrix and may OOM on long
+        sequences or large batches.
     """
 
     def __init__(
         self,
         batch_size: int = 10,
-        device: Literal["cpu", "cuda"] = "cpu",
+        device: str = "cpu",
         max_length: int = 12288,
         nproc: int = 1,
         output_attentions: bool = False,

--- a/helical/models/helix_mrna/model.py
+++ b/helical/models/helix_mrna/model.py
@@ -11,6 +11,7 @@ import numpy as np
 from tqdm import tqdm
 from typing import Union
 from pandas import DataFrame
+from transformers.utils import is_flash_attn_2_available
 
 import logging
 
@@ -60,7 +61,17 @@ class HelixmRNA(HelicalRNAModel):
         self.configurer = configurer
         self.config = configurer.config
 
-        self.model = HelixmRNAPretrainedModel.from_pretrained(self.config["model_name"])
+        if self.config["output_attentions"]:
+            attn_impl = "eager"
+        elif is_flash_attn_2_available():
+            attn_impl = "flash_attention_2"
+        else:
+            attn_impl = "sdpa"
+        self.model = HelixmRNAPretrainedModel.from_pretrained(
+            self.config["model_name"],
+            attn_implementation=attn_impl,
+            torch_dtype=torch.bfloat16,
+        )
         self.pretrained_config = HelixmRNAPretrainedConfig.from_pretrained(
             self.config["model_name"], trust_remote=True
         )
@@ -140,7 +151,7 @@ class HelixmRNA(HelicalRNAModel):
 
                 last_hidden_states = output[0]
 
-                embeddings.append(last_hidden_states.cpu().numpy())
+                embeddings.append(last_hidden_states.float().cpu().numpy())
 
                 del batch
                 del output

--- a/helical/models/helix_mrna/model.py
+++ b/helical/models/helix_mrna/model.py
@@ -11,7 +11,7 @@ import numpy as np
 from tqdm import tqdm
 from typing import Union
 from pandas import DataFrame
-from transformers.utils import is_flash_attn_2_available
+from helical.utils.attn_backend import select_attn_backend
 
 import logging
 
@@ -61,16 +61,18 @@ class HelixmRNA(HelicalRNAModel):
         self.configurer = configurer
         self.config = configurer.config
 
-        if self.config["output_attentions"]:
-            attn_impl = "eager"
-        elif is_flash_attn_2_available():
-            attn_impl = "flash_attention_2"
-        else:
-            attn_impl = "sdpa"
+        attn_impl, model_dtype = select_attn_backend(
+            self.config["device"],
+            output_attentions=self.config.get("output_attentions", False),
+        )
+        if attn_impl == "flash_attention_2":
+            LOGGER.warning(
+                "Loading Helix-mRNA in bfloat16 for flash_attention_2 compatibility."
+            )
         self.model = HelixmRNAPretrainedModel.from_pretrained(
             self.config["model_name"],
             attn_implementation=attn_impl,
-            torch_dtype=torch.bfloat16,
+            torch_dtype=model_dtype,
         )
         self.pretrained_config = HelixmRNAPretrainedConfig.from_pretrained(
             self.config["model_name"], trust_remote=True
@@ -116,19 +118,34 @@ class HelixmRNA(HelicalRNAModel):
         LOGGER.info("Successfully processed the data for Helix-mRNA.")
         return dataset
 
-    def get_embeddings(self, dataset: Dataset) -> np.ndarray:
+    def get_embeddings(
+        self, dataset: Dataset, output_attentions: bool = False
+    ) -> np.ndarray:
         """Get the embeddings for the mRNA sequences.
 
         Parameters
         ----------
         dataset : HelixmRNADataset
             The dataset object.
+        output_attentions : bool, optional, default=False
+            Whether to also return the last-layer attention weights. Requires the
+            model to have been loaded with eager attention (set
+            ``output_attentions=True`` in ``HelixmRNAConfig``).
 
         Returns
         -------
         np.ndarray
             The embeddings array.
+        list, optional
+            Per-batch last-layer attention tensors of shape
+            ``(batch_size, num_heads, seq_length, seq_length)``. Only returned
+            when ``output_attentions=True``.
         """
+        if output_attentions and not self.config.get("output_attentions", False):
+            raise ValueError(
+                "output_attentions=True requires the model to be loaded with eager attention. "
+                "Set output_attentions=True in HelixmRNAConfig before instantiating the model."
+            )
         LOGGER.info("Started getting embeddings:")
         dataloader = DataLoader(
             dataset,
@@ -137,6 +154,7 @@ class HelixmRNA(HelicalRNAModel):
             shuffle=False,
         )
         embeddings = []
+        attentions = [] if output_attentions else None
 
         progress_bar = tqdm(dataloader, desc="Getting embeddings")
         with torch.no_grad():
@@ -147,16 +165,26 @@ class HelixmRNA(HelicalRNAModel):
                 )
                 attention_mask = 1 - special_tokens_mask
 
-                output = self.model(input_ids=input_ids, attention_mask=attention_mask)
+                output = self.model(
+                    input_ids=input_ids,
+                    attention_mask=attention_mask,
+                    output_attentions=output_attentions,
+                )
 
                 last_hidden_states = output[0]
+                embeddings.append(last_hidden_states.cpu().float().numpy())
 
-                embeddings.append(last_hidden_states.float().cpu().numpy())
+                if output_attentions:
+                    output_attn = getattr(output, "attentions", None)
+                    if output_attn:
+                        attentions.append(output_attn[-1].cpu().float().numpy())
 
                 del batch
                 del output
 
         LOGGER.info(f"Finished getting embeddings.")
+        if output_attentions:
+            return np.concatenate(embeddings), (attentions if attentions else None)
         return np.concatenate(embeddings)
 
     def _collate_fn(self, batch):

--- a/helical/models/helix_mrna/modeling_helix_mrna.py
+++ b/helical/models/helix_mrna/modeling_helix_mrna.py
@@ -1373,9 +1373,9 @@ class HelixmRNAPreTrainedModel(PreTrainedModel):
     _no_split_modules = ["HelixmRNAAttentionDecoderLayer", "Mamba2Block"]
     _skip_keys_device_placement = "past_key_values"
     _supports_flash_attn_2 = True
-    _supports_flash_attn = True  # transformers >= 4.53.0 renamed _supports_flash_attn_2
+    _supports_flash_attn = True
     _supports_sdpa = True
-    _supports_cache_class = True  # Note: only supports HybridMambaAttentionDynamicCache
+    _supports_cache_class = True  # only supports HybridMambaAttentionDynamicCache
 
     def _init_weights(self, module):
         """Initialize the weights."""
@@ -1447,6 +1447,7 @@ class HelixmRNAOutput(ModelOutput):
     last_hidden_state: Optional[torch.FloatTensor] = None
     cache_params: Optional[Mamba2Cache] = None
     hidden_states: Optional[Tuple[torch.FloatTensor]] = None
+    attentions: Optional[Tuple[torch.FloatTensor]] = None
 
 
 @dataclass
@@ -1670,15 +1671,19 @@ class HelixmRNAPretrainedModel(HelixmRNAPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (layer_outputs[0],)
 
+            # Mamba/MLP blocks return (hidden_states,); attention blocks return
+            # (hidden_states, attn_weights, ...). Only attention layers contribute.
+            if (
+                output_attentions
+                and len(layer_outputs) > 1
+                and layer_outputs[1] is not None
+            ):
+                all_self_attns += (layer_outputs[1],)
+
         hidden_states = self.norm_f(layer_outputs[0])
 
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
-
-            if output_attentions:
-                if layer_outputs[1] is not None:
-                    # append attentions only of attention layers. Mamba layers return `None` as the attention weights
-                    all_self_attns += (layer_outputs[1],)
 
         if use_cache:
             cache_params.seqlen_offset += inputs_embeds.shape[1]
@@ -1686,7 +1691,12 @@ class HelixmRNAPretrainedModel(HelixmRNAPreTrainedModel):
         if not return_dict:
             return tuple(
                 v
-                for v in [hidden_states, cache_params, all_hidden_states]
+                for v in [
+                    hidden_states,
+                    cache_params,
+                    all_hidden_states,
+                    all_self_attns,
+                ]
                 if v is not None
             )
 
@@ -1694,6 +1704,7 @@ class HelixmRNAPretrainedModel(HelixmRNAPreTrainedModel):
             last_hidden_state=hidden_states,
             cache_params=cache_params if use_cache else None,
             hidden_states=all_hidden_states,
+            attentions=all_self_attns,
         )
 
     def _update_causal_mask(self, attention_mask, input_tensor, cache_position):

--- a/helical/models/helix_mrna/modeling_helix_mrna.py
+++ b/helical/models/helix_mrna/modeling_helix_mrna.py
@@ -1373,6 +1373,7 @@ class HelixmRNAPreTrainedModel(PreTrainedModel):
     _no_split_modules = ["HelixmRNAAttentionDecoderLayer", "Mamba2Block"]
     _skip_keys_device_placement = "past_key_values"
     _supports_flash_attn_2 = True
+    _supports_flash_attn = True  # transformers >= 4.53.0 renamed _supports_flash_attn_2
     _supports_sdpa = True
     _supports_cache_class = True  # Note: only supports HybridMambaAttentionDynamicCache
 

--- a/helical/utils/attn_backend.py
+++ b/helical/utils/attn_backend.py
@@ -1,0 +1,19 @@
+import torch
+from transformers.utils import is_flash_attn_2_available
+
+
+def select_attn_backend(device, output_attentions: bool = False):
+    """Select attention implementation and dtype for transformers from_pretrained.
+
+    Returns
+    -------
+    (attn_impl, dtype) :
+        ``("eager", float32)`` if attention weights are needed;
+        ``("flash_attention_2", bfloat16)`` on CUDA when flash_attn is installed;
+        ``("sdpa", float32)`` otherwise.
+    """
+    if output_attentions:
+        return "eager", torch.float32
+    if is_flash_attn_2_available() and torch.device(device).type == "cuda":
+        return "flash_attention_2", torch.bfloat16
+    return "sdpa", torch.float32

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     'gitpython==3.1.44',
     'torch==2.7.0',
     'accelerate==1.4.0',
-    'transformers>=4.49.0,<=4.51.3',
+    'transformers>=4.53.0',
     'loompy==3.0.7',
     'scib==1.1.5',
     'scikit-misc>=0.5.2',


### PR DESCRIPTION
| Area | Change | Type | Breaking? | Notes |
|---|---|---|---|---|
| `transformers` dependency | `>=4.49.0,<=4.51.3` → `>=4.53.0` (unbounded) | Dependency bump | No (install) | No upper bound — future releases can break silently |
| `HelicalBaseFineTuningModel.save_model` | `torch.save(self.model)` → `torch.save(self.model.state_dict())` | Contract change | **Yes** | Previously-saved checkpoint files (pickled full objects) are unreadable by the new loader |
| `HelicalBaseFineTuningModel.load_model` | `torch.load(weights_only=False)` → `load_state_dict(torch.load(weights_only=True))` | Contract change | **Yes** | Pair with above; also closes arbitrary-pickle RCE risk |
| `GeneformerConfig` | New `output_attentions: bool = False` parameter | Additive | No | Load-time signal — determines attn backend at construction, not call time |
| `HelixmRNAConfig` | New `output_attentions: bool = False` parameter | Additive | No | Same semantics as Geneformer |
| `Geneformer.get_embeddings` | Raises `ValueError` if `output_attentions=True` without matching config flag | Contract tightening | **Yes** | Previously worked silently via transformers sdpa→eager fallback (removed in 4.53) |
| `Geneformer.__init__` attn backend | `(none)` → `eager` / `flash_attention_2`+bf16 / `sdpa` | Behaviour change | No | Flash path only activates on CUDA with `flash_attn` installed; sdpa otherwise |
| `Geneformer.__init__` dtype | Always float32 → bfloat16 on CUDA+flash, float32 otherwise | Behaviour change | No | Warning logged when bfloat16 selected |
| `geneformer_utils.get_embs` | `embs_i` and `attn_i` cast `.float()` before numpy | Correctness fix | No | Required for flash path; no-op on float32 paths |
| `geneformer_utils.load_model` | Added `output_attentions` param + same three-way attn/dtype logic | Additive | No | Duplicates `Geneformer.__init__` logic — these two paths can drift |
| `HelixmRNA.__init__` attn backend | `(none)` → `eager` / `flash_attention_2` / `sdpa` | Behaviour change | No | Mirrors Geneformer logic |
| `HelixmRNA` embeddings | `last_hidden_states.cpu().numpy()` → `.float().cpu().numpy()` | Correctness fix | No | Required for bfloat16 path; no-op on float32 |
| `helical/__init__.py` shim | Patches `GreedySearchDecoderOnlyOutput` / `SampleDecoderOnlyOutput` into `transformers.generation` | Compatibility shim | No | Required for `mamba_ssm` which still imports the removed 4.53 names |
| `CaduceusPreTrainedModel.all_tied_weights_keys` | Added as `{}` | Compatibility shim | No | 4.53 calls `.keys()` on this attribute; `{}` satisfies it; `[]` does not |
| `CaduceusPretrainedConfig.model_type` | Documented as required by 4.53 `from_pretrained` dispatch | Compatibility shim | No | Was already set as class attribute; now documented |
| `HelixmRNAPreTrainedModel._supports_flash_attn` | Added `= True` alongside existing `_supports_flash_attn_2` | Compatibility shim | No | 4.53 renamed the flag; both present for forward/backward compat |
| bio-agents `model_retrieval.py` | `output_attentions` not forwarded to `GeneformerConfig` | **Known gap** | **Yes** | Attention analysis via `GeneformerFineTuning` will now hit the new `ValueError` at inference time |
