### PR TITLE
Gate FA2 attention backend on model-class support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,6 +145,42 @@ jobs:
         run: |
           python examples/run_models/run_nicheformer.py ++device="cuda"
 
+  flash-attn-integration:
+    # Smoke-tests the flash_attn code paths that the main integration-tests job cannot
+    # exercise: flash_attn is not a declared helical dependency, so the FA2 branch in
+    # select_attn_backend is dormant there. This job installs flash_attn and verifies:
+    # (1) Geneformer (BertForMaskedLM, no FA2 via HF dispatch) still loads — regression
+    #     guard against routing BERT through attn_implementation='flash_attention_2'.
+    # (2) HelixmRNA actually loads and runs on the FA2 path.
+    needs: tests
+    runs-on: self-hosted
+    env:
+      CUDA_VISIBLE_DEVICES: 0
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.8
+
+      - name: Install helical with flash_attn
+        run: |
+            pip install .[mamba-ssm]
+            pip install flash-attn --no-build-isolation
+
+      - name: Smoke-test Geneformer (FA2 regression guard)
+        run: |
+          python -c "
+          from helical.models.geneformer import Geneformer, GeneformerConfig
+          Geneformer(GeneformerConfig(model_name='gf-6L-10M-i2048', device='cuda'))
+          "
+
+      - name: Smoke-test HelixmRNA on FA2 path
+        run: |
+          python examples/run_models/run_helix_mrna.py ++device="cuda"
+
   notebooks:
     needs: tests
     runs-on: self-hosted

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,43 @@ jobs:
       - name: Execute Nicheformer
         run: |
           python examples/run_models/run_nicheformer.py ++device="cuda"
-          
+
+  flash-attn-integration:
+    # Smoke-tests the flash_attn code paths that the main integration-tests job cannot
+    # exercise: flash_attn is not a declared helical dependency, so the FA2 branch in
+    # select_attn_backend is dormant there. This job installs flash_attn and verifies:
+    # (1) Geneformer (BertForMaskedLM, no FA2 via HF dispatch) still loads — regression
+    #     guard against routing BERT through attn_implementation='flash_attention_2'.
+    # (2) HelixmRNA actually loads and runs on the FA2 path.
+    needs: tests
+    runs-on: self-hosted
+    env:
+      CUDA_VISIBLE_DEVICES: 0
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.8
+
+      - name: Install helical with flash_attn
+        run: |
+            pip install .[mamba-ssm]
+            pip install flash-attn --no-build-isolation
+
+      - name: Smoke-test Geneformer (FA2 regression guard)
+        run: |
+          python -c "
+          from helical.models.geneformer import Geneformer, GeneformerConfig
+          Geneformer(GeneformerConfig(model_name='gf-6L-10M-i2048', device='cuda'))
+          "
+
+      - name: Smoke-test HelixmRNA on FA2 path
+        run: |
+          python examples/run_models/run_helix_mrna.py ++device="cuda"
+
   notebooks:
     needs: tests
     runs-on: self-hosted

--- a/ci/tests/test_utils/test_attn_backend.py
+++ b/ci/tests/test_utils/test_attn_backend.py
@@ -1,0 +1,48 @@
+import pytest
+import torch
+from helical.utils.attn_backend import select_attn_backend
+
+
+@pytest.fixture
+def fa2_available(mocker):
+    return mocker.patch(
+        "helical.utils.attn_backend.is_flash_attn_2_available", return_value=True
+    )
+
+
+@pytest.mark.parametrize("supports_fa2", [False, True])
+def test_output_attentions_forces_eager(supports_fa2, fa2_available):
+    attn, dtype = select_attn_backend(
+        "cuda", output_attentions=True, supports_fa2=supports_fa2
+    )
+    assert attn == "eager"
+    assert dtype == torch.float32
+
+
+def test_fa2_selected_when_supported_and_available(fa2_available):
+    attn, dtype = select_attn_backend(
+        "cuda", output_attentions=False, supports_fa2=True
+    )
+    assert attn == "flash_attention_2"
+    assert dtype == torch.bfloat16
+
+
+def test_sdpa_when_model_does_not_support_fa2(fa2_available):
+    """Regression guard: models without HF FA2 dispatch (e.g. BertForMaskedLM) must
+    never receive attn_implementation='flash_attention_2', even when flash_attn is
+    installed on CUDA. Transformers raises a hard ValueError otherwise."""
+    attn, _ = select_attn_backend("cuda", output_attentions=False, supports_fa2=False)
+    assert attn == "sdpa"
+
+
+def test_sdpa_when_fa2_unavailable(mocker):
+    mocker.patch(
+        "helical.utils.attn_backend.is_flash_attn_2_available", return_value=False
+    )
+    attn, _ = select_attn_backend("cuda", output_attentions=False, supports_fa2=True)
+    assert attn == "sdpa"
+
+
+def test_sdpa_on_cpu_even_with_fa2_available(fa2_available):
+    attn, _ = select_attn_backend("cpu", output_attentions=False, supports_fa2=True)
+    assert attn == "sdpa"

--- a/helical/models/geneformer/geneformer_utils.py
+++ b/helical/models/geneformer/geneformer_utils.py
@@ -268,13 +268,11 @@ def load_model(model_type, model_directory, device, output_attentions=False):
         raise ValueError(
             f"Unsupported model_type: {model_type!r}. Only 'Pretrained' is supported."
         )
+    # BertForMaskedLM does not declare FA2 support via HF dispatch; callers wanting
+    # FA2 for Geneformer must wire flash_attn directly.
     attn_impl, model_dtype = select_attn_backend(
         device, output_attentions=output_attentions
     )
-    if attn_impl == "flash_attention_2":
-        logger.warning(
-            "Loading Geneformer in bfloat16 for flash_attention_2 compatibility."
-        )
     model = BertForMaskedLM.from_pretrained(
         model_directory,
         output_hidden_states=True,

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -89,14 +89,12 @@ class Geneformer(HelicalRNAModel):
         for file in self.configurer.list_of_files_to_download:
             downloader.download_via_name(file)
 
+        # BertForMaskedLM does not declare FA2 support via HF dispatch; callers wanting
+        # FA2 for Geneformer must wire flash_attn directly.
         attn_impl, model_dtype = select_attn_backend(
             self.device,
             output_attentions=self.config.get("output_attentions", False),
         )
-        if attn_impl == "flash_attention_2":
-            LOGGER.warning(
-                "Loading Geneformer in bfloat16 for flash_attention_2 compatibility."
-            )
         self.model = BertForMaskedLM.from_pretrained(
             self.files_config["model_files_dir"],
             output_hidden_states=True,

--- a/helical/models/helix_mrna/model.py
+++ b/helical/models/helix_mrna/model.py
@@ -64,6 +64,7 @@ class HelixmRNA(HelicalRNAModel):
         attn_impl, model_dtype = select_attn_backend(
             self.config["device"],
             output_attentions=self.config.get("output_attentions", False),
+            supports_fa2=True,
         )
         if attn_impl == "flash_attention_2":
             LOGGER.warning(

--- a/helical/utils/attn_backend.py
+++ b/helical/utils/attn_backend.py
@@ -2,18 +2,33 @@ import torch
 from transformers.utils import is_flash_attn_2_available
 
 
-def select_attn_backend(device, output_attentions: bool = False):
+def select_attn_backend(
+    device, output_attentions: bool = False, supports_fa2: bool = False
+):
     """Select attention implementation and dtype for transformers from_pretrained.
+
+    Parameters
+    ----------
+    supports_fa2 : bool
+        Whether the target model class declares Flash Attention 2 support via HF's
+        ``_supports_flash_attn``/``_supports_flash_attn_2`` dispatcher. Required for the
+        ``"flash_attention_2"`` branch to be selected; models without it must wire
+        flash_attn directly at the consumer site.
 
     Returns
     -------
     (attn_impl, dtype) :
         ``("eager", float32)`` if attention weights are needed;
-        ``("flash_attention_2", bfloat16)`` on CUDA when flash_attn is installed;
+        ``("flash_attention_2", bfloat16)`` on CUDA when flash_attn is installed and the
+        model supports it;
         ``("sdpa", float32)`` otherwise.
     """
     if output_attentions:
         return "eager", torch.float32
-    if is_flash_attn_2_available() and torch.device(device).type == "cuda":
+    if (
+        supports_fa2
+        and is_flash_attn_2_available()
+        and torch.device(device).type == "cuda"
+    ):
         return "flash_attention_2", torch.bfloat16
     return "sdpa", torch.float32


### PR DESCRIPTION
Rationale
---------
select_attn_backend previously returned "flash_attention_2" whenever flash_attn was installed and the device was CUDA, without checking whether the target model class actually declares FA2 support via HF's dispatcher. For BertForMaskedLM (Geneformer) that silently routed the model down a code path transformers can't actually dispatch, so the "Loading ... in bfloat16 for flash_attention_2 compatibility" warning wasn't just cosmetic noise — it flagged a branch that couldn't work. The helical integration-tests job doesn't install flash_attn, so this gap was invisible in CI.

Plan
----
* Add a supports_fa2 parameter to select_attn_backend. Only models whose class declares _supports_flash_attn / _supports_flash_attn_2 can take the FA2 branch; others (Geneformer) fall back to sdpa.
* Pass supports_fa2=True from HelixmRNA. Leave Geneformer on the default (False) and annotate the call site so callers who want FA2 for BertForMaskedLM know they have to wire flash_attn directly.
* Drop the now-unreachable bfloat16-for-FA2 warnings from Geneformer; the sdpa fallback path never triggers them.
* Add a flash-attn-integration CI job that installs flash_attn and smoke-tests both paths: Geneformer (regression guard — must still load on sdpa even with flash_attn present) and HelixmRNA (must actually run on the FA2 branch).