### PR TITLE
Fix save_model to include fine-tuning head weights

### DIFF
--- a/ci/tests/test_geneformer/test_fine_tuning.py
+++ b/ci/tests/test_geneformer/test_fine_tuning.py
@@ -2,6 +2,8 @@ from helical.models.geneformer.fine_tuning_model import GeneformerFineTuningMode
 from helical.models.geneformer.model import GeneformerConfig
 from helical.models.fine_tune.fine_tuning_heads import ClassificationHead
 import os
+import tempfile
+import torch
 
 def test_save_and_load_model():
 
@@ -18,3 +20,34 @@ def test_save_and_load_model():
     finally:
         if os.path.exists("./geneformer_fine_tuned_model.pt"):
             os.remove("./geneformer_fine_tuned_model.pt")
+
+def test_save_and_load_preserves_fine_tuning_head_weights():
+    """Verify that save_model persists fine-tuning head weights and
+    load_model restores them exactly."""
+    config = GeneformerConfig()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "model.pt")
+
+        # Create model and set recognizable head weights.
+        model = GeneformerFineTuningModel(config, "classification", 10)
+        with torch.no_grad():
+            for param in model.fine_tuning_head.parameters():
+                param.fill_(42.0)
+        saved_head_state = {
+            k: v.clone()
+            for k, v in model.fine_tuning_head.state_dict().items()
+        }
+
+        model.save_model(path)
+
+        # Create a fresh model whose head has different (random) weights.
+        model2 = GeneformerFineTuningModel(config, "classification", 10)
+        model2.load_model(path)
+
+        loaded_head_state = model2.fine_tuning_head.state_dict()
+        for key in saved_head_state:
+            assert key in loaded_head_state, f"Missing head key: {key}"
+            assert torch.equal(saved_head_state[key], loaded_head_state[key]), (
+                f"Head weight mismatch for {key}"
+            )

--- a/ci/tests/test_geneformer/test_fine_tuning.py
+++ b/ci/tests/test_geneformer/test_fine_tuning.py
@@ -41,7 +41,7 @@ def test_save_and_load_preserves_fine_tuning_head_weights():
 
         model.save_model(path)
 
-        # Create a fresh model whose head has different (random) weights.
+        # Create a fresh model to load into.
         model2 = GeneformerFineTuningModel(config, "classification", 10)
         model2.load_model(path)
 

--- a/helical/models/base_models.py
+++ b/helical/models/base_models.py
@@ -284,22 +284,31 @@ class HelicalBaseFineTuningModel(torch.nn.Module):
         """
         Save the model to a file.
 
+        Persists the state dicts of both the backbone model and the
+        fine-tuning head so that :meth:`load_model` can fully restore a
+        fine-tuned checkpoint.
+
         Parameters
         ----------
         path : str
             The path to save the model to.
         """
-        torch.save(self.model.state_dict(), path)
+        torch.save(self.state_dict(), path)
         LOGGER.info(f"Model saved to {path}")
 
     def load_model(self, path: str):
         """
         Load the model from a file.
 
-        Accepts both current state-dict checkpoints and legacy pickle checkpoints
-        (saved with the old ``torch.save(model, path)`` API).  The secure state-dict
-        load is attempted first; on failure we fall back to unpickling the legacy
-        full-model object and extracting its state dict.
+        Accepts three checkpoint formats in order of preference:
+
+        1. **Current** -- a state dict produced by :meth:`save_model` that
+           contains keys for both ``model.*`` and ``fine_tuning_head.*``.
+        2. **Backbone-only** -- a v2.0.0 state dict that only contains
+           ``model.*`` keys (fine-tuning head is left at its current weights).
+        3. **Legacy pickle** -- a full-model pickle produced by the pre-v2.0.0
+           ``torch.save(model, path)`` API. The backbone state dict is
+           extracted and loaded; the fine-tuning head is left unchanged.
 
         Parameters
         ----------
@@ -316,7 +325,24 @@ class HelicalBaseFineTuningModel(torch.nn.Module):
             legacy = torch.load(path, weights_only=False)
             state_dict = legacy.state_dict() if not isinstance(legacy, dict) else legacy
 
-        self.model.load_state_dict(state_dict)
+        # Detect whether the checkpoint contains fine-tuning head keys.
+        has_head_keys = any(k.startswith("fine_tuning_head.") for k in state_dict)
+        has_model_keys = any(k.startswith("model.") for k in state_dict)
+
+        if has_model_keys and has_head_keys:
+            # Full checkpoint saved by the current save_model.
+            self.load_state_dict(state_dict)
+        elif has_model_keys:
+            # Backbone-only checkpoint (v2.0.0 save_model).
+            LOGGER.warning(
+                "Checkpoint contains only backbone weights; "
+                "fine-tuning head weights are left unchanged."
+            )
+            self.load_state_dict(state_dict, strict=False)
+        else:
+            # Legacy or bare backbone state dict without the 'model.' prefix.
+            self.model.load_state_dict(state_dict)
+
         self.model.eval()
         self.fine_tuning_head.eval()
         LOGGER.info(f"Model loaded from {path}")


### PR DESCRIPTION
## Summary

- `save_model()` currently calls `torch.save(self.model.state_dict(), path)`, which only persists backbone weights and silently drops the `fine_tuning_head`
- Users who fine-tune, save, and reload get random head weights instead of trained ones
- Affects all 7 model types (Geneformer, scGPT, UCE, HyenaDNA, Caduceus, HelixmRNA, Mamba2mRNA)
- Changed to `self.state_dict()` which includes both backbone and head
- Updated `load_model` to auto-detect three checkpoint formats for backward compatibility (full, backbone-only, legacy pickle)

## Test plan

- [ ] Fine-tune a model, save, reload — verify head weights are preserved
- [ ] Load a v2.0.0 backbone-only checkpoint — verify warning is logged and backbone loads correctly
- [ ] Load a pre-v2.0.0 legacy pickle checkpoint — verify backward compatibility


🤖 Generated with [Claude Code](https://claude.com/claude-code)