### PR TITLE
fix(security): set DataLoader pin_memory explicitly (automatic memory pinning)

### DIFF
--- a/helical/models/caduceus/fine_tuning_model.py
+++ b/helical/models/caduceus/fine_tuning_model.py
@@ -206,6 +206,7 @@ class CaduceusFineTuningModel(HelicalBaseFineTuningModel, Caduceus):
             collate_fn=self._collate_fn,
             batch_size=self.config["batch_size"],
             num_workers=self.config["nproc"],
+            pin_memory=torch.cuda.is_available(),
         )
 
         lr_scheduler = None
@@ -222,6 +223,7 @@ class CaduceusFineTuningModel(HelicalBaseFineTuningModel, Caduceus):
                 collate_fn=self._collate_fn,
                 batch_size=self.config["batch_size"],
                 num_workers=self.config["nproc"],
+                pin_memory=torch.cuda.is_available(),
             )
 
         LOGGER.info("Starting Fine-Tuning")
@@ -308,6 +310,7 @@ class CaduceusFineTuningModel(HelicalBaseFineTuningModel, Caduceus):
             batch_size=self.config["batch_size"],
             shuffle=False,
             num_workers=self.config["nproc"],
+            pin_memory=torch.cuda.is_available(),
         )
         outputs = []
 

--- a/helical/models/caduceus/model.py
+++ b/helical/models/caduceus/model.py
@@ -179,6 +179,7 @@ class Caduceus(HelicalDNAModel):
             batch_size=self.config["batch_size"],
             shuffle=False,
             num_workers=self.config["nproc"],
+            pin_memory=torch.cuda.is_available(),
         )
 
         embeddings = []

--- a/helical/models/evo_2/model.py
+++ b/helical/models/evo_2/model.py
@@ -145,6 +145,7 @@ class Evo2(HelicalDNAModel):
             collate_fn=self._collate_fn,
             batch_size=self.config["batch_size"],
             shuffle=False,
+            pin_memory=torch.cuda.is_available(),
         )
 
         embeddings = {"embeddings": [], "original_lengths": []}

--- a/helical/models/helix_mrna/fine_tuning_model.py
+++ b/helical/models/helix_mrna/fine_tuning_model.py
@@ -192,6 +192,7 @@ class HelixmRNAFineTuningModel(HelicalBaseFineTuningModel, HelixmRNA):
             train_dataset,
             collate_fn=self._collate_fn,
             batch_size=self.config["batch_size"],
+            pin_memory=torch.cuda.is_available(),
         )
 
         lr_scheduler = None
@@ -207,6 +208,7 @@ class HelixmRNAFineTuningModel(HelicalBaseFineTuningModel, HelixmRNA):
                 validation_dataset,
                 collate_fn=self._collate_fn,
                 batch_size=self.config["batch_size"],
+                pin_memory=torch.cuda.is_available(),
             )
 
         LOGGER.info("Starting Fine-Tuning")
@@ -292,6 +294,7 @@ class HelixmRNAFineTuningModel(HelicalBaseFineTuningModel, HelixmRNA):
             collate_fn=self._collate_fn,
             batch_size=self.config["batch_size"],
             shuffle=False,
+            pin_memory=torch.cuda.is_available(),
         )
         outputs = []
 

--- a/helical/models/helix_mrna/model.py
+++ b/helical/models/helix_mrna/model.py
@@ -153,6 +153,7 @@ class HelixmRNA(HelicalRNAModel):
             collate_fn=self._collate_fn,
             batch_size=self.config["batch_size"],
             shuffle=False,
+            pin_memory=torch.cuda.is_available(),
         )
         embeddings = []
         attentions = [] if output_attentions else None

--- a/helical/models/hyena_dna/fine_tuning_model.py
+++ b/helical/models/hyena_dna/fine_tuning_model.py
@@ -127,6 +127,7 @@ class HyenaDNAFineTuningModel(HelicalBaseFineTuningModel, HyenaDNA):
             collate_fn=self._collate_fn,
             batch_size=self.config["batch_size"],
             shuffle=shuffle,
+            pin_memory=torch.cuda.is_available(),
         )
 
         if validation_dataset is not None and validation_labels is not None:
@@ -137,6 +138,7 @@ class HyenaDNAFineTuningModel(HelicalBaseFineTuningModel, HyenaDNA):
                 validation_dataset,
                 collate_fn=self._collate_fn,
                 batch_size=self.config["batch_size"],
+                pin_memory=torch.cuda.is_available(),
             )
 
         self.to(self.config["device"])
@@ -206,7 +208,10 @@ class HyenaDNAFineTuningModel(HelicalBaseFineTuningModel, HyenaDNA):
             The outputs of the model
         """
         data_loader = DataLoader(
-            dataset, collate_fn=self._collate_fn, batch_size=self.config["batch_size"]
+            dataset,
+            collate_fn=self._collate_fn,
+            batch_size=self.config["batch_size"],
+            pin_memory=torch.cuda.is_available(),
         )
 
         self.to(self.config["device"])

--- a/helical/models/hyena_dna/model.py
+++ b/helical/models/hyena_dna/model.py
@@ -139,7 +139,10 @@ class HyenaDNA(HelicalDNAModel):
         LOGGER.info(f"Started getting embeddings:")
 
         train_data_loader = DataLoader(
-            dataset, collate_fn=self._collate_fn, batch_size=self.config["batch_size"]
+            dataset,
+            collate_fn=self._collate_fn,
+            batch_size=self.config["batch_size"],
+            pin_memory=torch.cuda.is_available(),
         )
         with torch.inference_mode():
             embeddings = []

--- a/helical/models/mamba2_mrna/fine_tuning_model.py
+++ b/helical/models/mamba2_mrna/fine_tuning_model.py
@@ -207,6 +207,7 @@ class Mamba2mRNAFineTuningModel(HelicalBaseFineTuningModel, Mamba2mRNA):
             collate_fn=self._collate_fn,
             batch_size=self.config["batch_size"],
             shuffle=shuffle,
+            pin_memory=torch.cuda.is_available(),
         )
 
         # initialise lr_scheduler
@@ -223,6 +224,7 @@ class Mamba2mRNAFineTuningModel(HelicalBaseFineTuningModel, Mamba2mRNA):
                 validation_dataset,
                 collate_fn=self._collate_fn,
                 batch_size=self.config["batch_size"],
+                pin_memory=torch.cuda.is_available(),
             )
 
         logger.info("Starting Fine-Tuning")
@@ -317,6 +319,7 @@ class Mamba2mRNAFineTuningModel(HelicalBaseFineTuningModel, Mamba2mRNA):
             collate_fn=self._collate_fn,
             batch_size=self.config["batch_size"],
             shuffle=False,
+            pin_memory=torch.cuda.is_available(),
         )
         outputs = []
 

--- a/helical/models/mamba2_mrna/model.py
+++ b/helical/models/mamba2_mrna/model.py
@@ -119,6 +119,7 @@ class Mamba2mRNA(HelicalRNAModel):
             collate_fn=self._collate_fn,
             batch_size=self.config["batch_size"],
             shuffle=False,
+            pin_memory=torch.cuda.is_available(),
         )
         embeddings = []
 

--- a/helical/models/scgpt/fine_tuning_model.py
+++ b/helical/models/scgpt/fine_tuning_model.py
@@ -188,7 +188,7 @@ class scGPTFineTuningModel(HelicalBaseFineTuningModel, scGPT):
             sampler=SequentialSampler(train_input_data),
             collate_fn=collator,
             drop_last=False,
-            pin_memory=True,
+            pin_memory=torch.cuda.is_available(),
         )
 
         if validation_input_data is not None:
@@ -198,7 +198,7 @@ class scGPTFineTuningModel(HelicalBaseFineTuningModel, scGPT):
                 sampler=SequentialSampler(validation_input_data),
                 collate_fn=collator,
                 drop_last=False,
-                pin_memory=True,
+                pin_memory=torch.cuda.is_available(),
             )
 
         self.to(device)
@@ -325,7 +325,7 @@ class scGPTFineTuningModel(HelicalBaseFineTuningModel, scGPT):
             sampler=SequentialSampler(dataset),
             collate_fn=collator,
             drop_last=False,
-            pin_memory=True,
+            pin_memory=torch.cuda.is_available(),
         )
 
         testing_loop = tqdm(data_loader, desc="Fine-Tuning Validation")

--- a/helical/models/scgpt/model.py
+++ b/helical/models/scgpt/model.py
@@ -150,7 +150,7 @@ class scGPT(HelicalRNAModel):
             sampler=SequentialSampler(dataset),
             collate_fn=collator,
             drop_last=False,
-            pin_memory=True,
+            pin_memory=torch.cuda.is_available(),
         )
 
         device = next(self.model.parameters()).device

--- a/helical/models/tahoe/tahoe_x1/utils.py
+++ b/helical/models/tahoe/tahoe_x1/utils.py
@@ -73,7 +73,7 @@ def loader_from_adata(
         shuffle=False,
         drop_last=False,
         num_workers=num_workers,
-        pin_memory=True,
+        pin_memory=torch.cuda.is_available(),
         prefetch_factor=prefetch_factor,
     )
 

--- a/helical/models/transcriptformer/model.py
+++ b/helical/models/transcriptformer/model.py
@@ -223,7 +223,7 @@ class TranscriptFormer(HelicalRNAModel):
             batch_size=self.model.inference_config.batch_size,
             num_workers=self.model.data_config.n_data_workers,
             drop_last=False,
-            pin_memory=True,
+            pin_memory=torch.cuda.is_available(),
             collate_fn=dataset.collate_fn,
         )
 

--- a/helical/models/uce/fine_tuning_model.py
+++ b/helical/models/uce/fine_tuning_model.py
@@ -156,6 +156,7 @@ class UCEFineTuningModel(HelicalBaseFineTuningModel, UCE):
             shuffle=False,
             collate_fn=train_input_data.collator_fn,
             num_workers=0,
+            pin_memory=torch.cuda.is_available(),
         )
 
         if validation_input_data is not None:
@@ -165,6 +166,7 @@ class UCEFineTuningModel(HelicalBaseFineTuningModel, UCE):
                 shuffle=False,
                 collate_fn=validation_input_data.collator_fn,
                 num_workers=0,
+                pin_memory=torch.cuda.is_available(),
             )
 
         if self.accelerator is not None:
@@ -291,6 +293,7 @@ class UCEFineTuningModel(HelicalBaseFineTuningModel, UCE):
             shuffle=False,
             collate_fn=dataset.collator_fn,
             num_workers=0,
+            pin_memory=torch.cuda.is_available(),
         )
 
         if self.accelerator is not None:

--- a/helical/models/uce/model.py
+++ b/helical/models/uce/model.py
@@ -229,6 +229,7 @@ class UCE(HelicalRNAModel):
             shuffle=False,
             collate_fn=dataset.collator_fn,
             num_workers=0,
+            pin_memory=torch.cuda.is_available(),
         )
 
         if self.accelerator is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helical"
-version = "2.1.0"
+version = "2.1.1"
 
 authors = [
   { name="Helical Team", email="support@helical-ai.com" },


### PR DESCRIPTION
## What & why

Trail of Bits' Semgrep rule `automatic-memory-pinning` (CWE-676) flags every `torch.utils.data.DataLoader` that leaves `pin_memory` unset — the pinning behaviour is then implicit/undefined.

This PR sets the choice **explicitly** on all **27 DataLoader call sites** (15 files):

```python
pin_memory=torch.cuda.is_available()
```

- **Pins host memory only when a CUDA GPU is present** → faster, asynchronous host→GPU transfers during training/inference.
- **Avoids wasting scarce page-locked memory on CPU-only machines**, where unconditional pinning gives no benefit and can add overhead.

## Scope

- **21 flagged sites** (mamba2_mrna, hyena_dna, helix_mrna, uce, evo_2, caduceus): added the `pin_memory` kwarg.
- **6 previously-hardcoded `pin_memory=True`** (scgpt ×4, tahoe ×1, transcriptformer ×1): unified to the same predicate so they no longer pin unconditionally on CPU-only runs.

## Validation

- All 27 DataLoaders now carry `pin_memory=torch.cuda.is_available()`; 0 leftover `pin_memory=True`.
- All touched files compile (`py_compile`) and import `torch`.
- Behavioural no-op on CPU (CI); no test asserts on `pin_memory`.

## Review note

A high-effort code review flagged that `torch.cuda.is_available()` keys on *global* CUDA presence rather than the model's *configured* device — so on a GPU host where a user explicitly selects `device="cpu"`, pinned memory is still allocated. This is a minor, edge-case performance concern (no correctness bug). We deliberately kept `torch.cuda.is_available()` as it is the ToB-recommended idiom and satisfies the scan; a per-model configured-device check was deemed more invasive/risky for the benefit.

Refs: `trailofbits.python.automatic-memory-pinning`

🤖 Generated with [Claude Code](https://claude.com/claude-code)