### PR TITLE
docs(security): annotate CWE-502 pickle/torch.load sites (Refs helicalAI/dashboard#1154)

### DIFF
--- a/helical/models/base_models.py
+++ b/helical/models/base_models.py
@@ -316,12 +316,18 @@ class HelicalBaseFineTuningModel(torch.nn.Module):
             The path to load the model from.
         """
         try:
+            # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/base_models.py#L319-L319
+            # Reached from dags repo: none (bio-agent uses its own loader bioagents/tracking/tracking.py load_model_from_file, not helical's load_model; reached only from helical examples/fine_tune_models/*.py and ci tests)
+            # Pickle written at: helical/models/base_models.py:296 (torch.save -- save_model writes torch.save(self.state_dict(), path))
             state_dict = torch.load(path, weights_only=True)
         except Exception:
             LOGGER.warning(
                 f"State-dict load failed for {path}; "
                 f"attempting to load as a legacy pickle checkpoint."
             )
+            # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/base_models.py#L325-L325
+            # Reached from dags repo: none (bio-agent uses its own loader bioagents/tracking/tracking.py load_model_from_file, not helical's load_model; reached only from helical examples/fine_tune_models/*.py and ci tests)
+            # Pickle written at: helical/models/base_models.py:296 (torch.save); this weights_only=False branch consumes pre-v2.0.0 full-model pickles written externally by legacy torch.save(model, path)
             legacy = torch.load(path, weights_only=False)
             state_dict = legacy.state_dict() if not isinstance(legacy, dict) else legacy
 

--- a/helical/models/geneformer/geneformer_tokenizer.py
+++ b/helical/models/geneformer/geneformer_tokenizer.py
@@ -254,10 +254,16 @@ class TranscriptomeTokenizer:
         # load dictionary of gene normalization factors
         # (non-zero median value of expression across Genecorpus-30M)
         with open(gene_median_file, "rb") as f:
+            # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/geneformer/geneformer_tokenizer.py#L257-L257
+            # Reached from dags repo: finetuning_dag.py (dag_id="finetuning") / nebius_finetuning_dag.py (dag_id="nebius_finetuning") / brian_nebius_finetuning.py (dag_id="brian_nebius_finetuning") -> finetuning_script.py; embedding_dag.py (dag_id="embedding") & brian_embedding_dag.py (dag_id="brian_embedding") -> embedding_script.py; attention_analysis_dag.py (dag_id="attention_analysis") -> attention_analysis_script.py; perturbation_dag.py (dag_id="perturbation") -> perturbation_script.py; evaluation_dag.py (dag_id="evaluation") -> evaluation_script.py (all -> Geneformer.__init__ -> TranscriptomeTokenizer)
+            # Pickle written externally: downloaded model artifact from Helical S3 (bucket helicalpackage, eu-west-2) key geneformer/{model_version}/gene_median_dictionary.pkl (helical/utils/downloader.py:72)
             self.gene_median_dict = pickle.load(f)
 
         # load token dictionary (Ensembl IDs:token)
         with open(token_dictionary_file, "rb") as f:
+            # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/geneformer/geneformer_tokenizer.py#L261-L261
+            # Reached from dags repo: finetuning_dag.py (dag_id="finetuning") / nebius_finetuning_dag.py (dag_id="nebius_finetuning") / brian_nebius_finetuning.py (dag_id="brian_nebius_finetuning") -> finetuning_script.py; embedding_dag.py (dag_id="embedding") & brian_embedding_dag.py (dag_id="brian_embedding") -> embedding_script.py; attention_analysis_dag.py (dag_id="attention_analysis") -> attention_analysis_script.py; perturbation_dag.py (dag_id="perturbation") -> perturbation_script.py; evaluation_dag.py (dag_id="evaluation") -> evaluation_script.py (all -> Geneformer.__init__ -> TranscriptomeTokenizer)
+            # Pickle written externally: downloaded model artifact from Helical S3 (bucket helicalpackage, eu-west-2) key geneformer/{model_version}/token_dictionary.pkl (helical/utils/downloader.py:72)
             self.gene_token_dict = pickle.load(f)
 
         # check for special token in gene_token_dict
@@ -284,6 +290,9 @@ class TranscriptomeTokenizer:
         # load gene mappings dictionary (Ensembl IDs:Ensembl ID)
         if gene_mapping_file is not None:
             with open(gene_mapping_file, "rb") as f:
+                # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/geneformer/geneformer_tokenizer.py#L287-L287
+                # Reached from dags repo: finetuning_dag.py (dag_id="finetuning") / nebius_finetuning_dag.py (dag_id="nebius_finetuning") / brian_nebius_finetuning.py (dag_id="brian_nebius_finetuning") -> finetuning_script.py; embedding_dag.py (dag_id="embedding") & brian_embedding_dag.py (dag_id="brian_embedding") -> embedding_script.py; attention_analysis_dag.py (dag_id="attention_analysis") -> attention_analysis_script.py; perturbation_dag.py (dag_id="perturbation") -> perturbation_script.py; evaluation_dag.py (dag_id="evaluation") -> evaluation_script.py (all -> Geneformer.__init__ -> TranscriptomeTokenizer)
+                # Pickle written externally: downloaded model artifact from Helical S3 (bucket helicalpackage, eu-west-2) key geneformer/{model_version}/ensembl_mapping_dict.pkl (helical/utils/downloader.py:72)
                 self.gene_mapping_dict = pickle.load(f)
         else:
             self.gene_mapping_dict = {k: k for k, _ in self.gene_token_dict.items()}

--- a/helical/models/geneformer/geneformer_utils.py
+++ b/helical/models/geneformer/geneformer_utils.py
@@ -35,6 +35,9 @@ def load_mappings(gene_symbols):
         gene_id_to_ensemble.update(decoded)
         # print(repr(decoded))
 
+    # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/geneformer/geneformer_utils.py#L38-L38
+    # Reached from dags repo: none (dead code: enclosing load_mappings() at line 21 has no caller in helical, bio-agent, or dags)
+    # No in-repo reader: output ./human_gene_to_ensemble_id.pkl consumed by user/downstream (no pickle.load / pd.read_pickle of it anywhere in the three repos)
     pkl.dump(gene_id_to_ensemble, open("./human_gene_to_ensemble_id.pkl", "wb"))
     return gene_id_to_ensemble
 

--- a/helical/models/hyena_dna/pretrained_model.py
+++ b/helical/models/hyena_dna/pretrained_model.py
@@ -79,6 +79,9 @@ class HyenaDNAPreTrainedModel(PreTrainedModel):
         scratch_model = HyenaDNAModel(
             **config, use_head=use_head, n_classes=n_classes
         )  # the new model format
+        # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/hyena_dna/pretrained_model.py#L82-L84
+        # Reached from dags repo: finetuning_dag.py (dag_id="finetuning") / nebius_finetuning_dag.py (dag_id="nebius_finetuning") / brian_nebius_finetuning.py (dag_id="brian_nebius_finetuning") -> finetuning_script.py -> bioagents get_fine_tuning_model -> HyenaDNAFineTuning -> HyenaDNA.__init__ -> HyenaDNAPreTrainedModel.from_pretrained
+        # Pickle written externally: downloaded model artifact from Helical S3 (bucket helicalpackage) key hyena_dna/{model_name}.ckpt (helical/models/hyena_dna/hyena_dna_config.py:108; upstream LongSafari HyenaDNA)
         loaded_ckpt = torch.load(
             config["model_path"], map_location=torch.device(device), weights_only=False
         )

--- a/helical/models/scgpt/scgpt_utils.py
+++ b/helical/models/scgpt/scgpt_utils.py
@@ -100,6 +100,9 @@ def load_model(model_configs: scGPTConfig):
 
     load_pretrained(
         model,
+        # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/scgpt/scgpt_utils.py#L103-L103
+        # Reached from dags repo: embedding_dag.py (dag_id="embedding") & brian_embedding_dag.py (dag_id="brian_embedding") -> embedding_script.py; finetuning_dag.py (dag_id="finetuning") / nebius_finetuning_dag.py (dag_id="nebius_finetuning") / brian_nebius_finetuning.py (dag_id="brian_nebius_finetuning") -> finetuning_script.py (scgpt is the default model; via bioagents get_fine_tuning_model -> scGPTFineTuning -> scGPT.__init__)
+        # Pickle written externally: downloaded model artifact from Helical S3 (bucket helicalpackage) key scgpt/scGPT_CP/best_model.pt (helical/utils/downloader.py:72; upstream bowang-lab/scGPT)
         torch.load(model_configs["model_path"], map_location=model_configs["device"]),
         verbose=False,
     )

--- a/helical/models/tahoe/tahoe_x1/model/blocks.py
+++ b/helical/models/tahoe/tahoe_x1/model/blocks.py
@@ -382,6 +382,9 @@ class GeneEncoder(nn.Module):
 
         for name, e_cfg in additional_embedding_cfg.items():
             local_path = e_cfg["local"]
+            # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/tahoe/tahoe_x1/model/blocks.py#L385-L385
+            # Reached from dags repo: none (Tahoe is not imported in bioagents/ or dags/; run only via helical examples/run_models/run_tahoe.py and examples/notebooks/Tahoe-x1-Tutorial.ipynb)
+            # Pickle written externally: Hugging Face repo tahoebio/Tahoe-x1 (additional-embedding file e_cfg["local"] fetched via TXModel.from_hf -> hf_hub_download)
             pretrained_weight = torch.load(local_path, weights_only=True)["embedding.weight"]
             pretrained_vocab_size, pretrained_dim = pretrained_weight.shape
             if pretrained_vocab_size < num_embeddings:

--- a/helical/models/tahoe/tahoe_x1/tokenizer/gene_tokenizer.py
+++ b/helical/models/tahoe/tahoe_x1/tokenizer/gene_tokenizer.py
@@ -173,6 +173,9 @@ class GeneVocab:
             file_path = Path(file_path)
         if file_path.suffix == ".pkl":
             with file_path.open("rb") as f:
+                # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/tahoe/tahoe_x1/tokenizer/gene_tokenizer.py#L176-L176
+                # Reached from dags repo: none (Tahoe unused in bioagents/dags; Tahoe's own loader uses vocab.json (json branch), so this .pkl branch fires only if a local .pkl vocab is passed, e.g. helical examples/tutorial)
+                # Pickle written externally: Hugging Face repo tahoebio/Tahoe-x1 ships vocab as vocab.json, not .pkl; no in-repo .pkl writer exists
                 vocab = pickle.load(f)
             return cls(vocab)
         elif file_path.suffix == ".json":

--- a/helical/models/transcriptformer/model.py
+++ b/helical/models/transcriptformer/model.py
@@ -128,6 +128,9 @@ class TranscriptFormer(HelicalRNAModel):
             )
 
         logger.info("Loading model checkpoint")
+        # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/transcriptformer/model.py#L131-L133
+        # Reached from dags repo: embedding_dag.py (dag_id="embedding") & brian_embedding_dag.py (dag_id="brian_embedding") -> embedding_script.py; finetuning_dag.py (dag_id="finetuning") / nebius_finetuning_dag.py (dag_id="nebius_finetuning") / brian_nebius_finetuning.py (dag_id="brian_nebius_finetuning") -> finetuning_script.py (via bioagents get_fine_tuning_model -> TranscriptformerFineTuning -> TranscriptFormer.__init__)
+        # Pickle written externally: downloaded model artifact from Helical S3 (bucket helicalpackage) key transcriptformer/{model_name}/model_weights.pt (helical/utils/downloader.py:72)
         state_dict = torch.load(
             self.model.inference_config.load_checkpoint, weights_only=True, map_location=torch.device("cpu")
         )

--- a/helical/models/transcriptformer/utils/utils.py
+++ b/helical/models/transcriptformer/utils/utils.py
@@ -12,6 +12,9 @@ logger = logging.getLogger(__name__)
 def load_embeddings(embeddings_path):
     with open(embeddings_path, "rb") as f:
         if embeddings_path.endswith(".pkl"):
+            # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/transcriptformer/utils/utils.py#L15-L15
+            # Reached from dags repo: embedding_dag.py (dag_id="embedding") / finetuning_dag.py (dag_id="finetuning") / nebius_finetuning_dag.py (dag_id="nebius_finetuning") / brian_nebius_finetuning.py (dag_id="brian_nebius_finetuning") -> embedding_script.py / finetuning_script.py -> TranscriptFormer.change_embedding_layer, but only when pretrained_embedding points to a user-supplied .pkl (Helical's own embeddings ship as .h5)
+            # Pickle written externally: user-supplied out-of-distribution embedding .pkl; no in-repo writer (Helical ships/downloads embeddings as .h5)
             embeddings = pickle.load(f)
         elif embeddings_path.endswith(".h5"):
             embeddings = load_from_hdf5(embeddings_path)

--- a/helical/models/uce/gene_embeddings.py
+++ b/helical/models/uce/gene_embeddings.py
@@ -65,6 +65,9 @@ def load_gene_embeddings_adata(
     species_to_gene_symbol_to_embedding = {
         species: {
             gene_symbol.lower(): gene_embedding
+            # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/uce/gene_embeddings.py#L68-L70
+            # Reached from dags repo: none (no DAG or bioagents script invokes UCE; only manual example bio-agent/examples/cross_species_integration/README.md)
+            # Pickle written externally: downloaded model artifact from Helical S3 (bucket helicalpackage) key uce/protein_embeddings/<Species>.gene_symbol_to_embedding_ESM2.pt (helical/models/uce/uce_config.py:119)
             for gene_symbol, gene_embedding in torch.load(
                 species_to_gene_embedding_path[species]
             ).items()
@@ -103,6 +106,9 @@ def load_gene_embeddings_adata(
     species_to_all_gene_symbols = {
         species: [
             gene_symbol.lower()
+            # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/uce/gene_embeddings.py#L106-L108
+            # Reached from dags repo: none (no DAG or bioagents script invokes UCE; only manual example bio-agent/examples/cross_species_integration/README.md)
+            # Pickle written externally: downloaded model artifact from Helical S3 (bucket helicalpackage) key uce/protein_embeddings/<Species>.gene_symbol_to_embedding_ESM2.pt (helical/models/uce/uce_config.py:119)
             for gene_symbol, _ in torch.load(
                 species_to_gene_embedding_path[species]
             ).items()

--- a/helical/models/uce/uce_utils.py
+++ b/helical/models/uce/uce_utils.py
@@ -53,6 +53,9 @@ def get_ESM2_embeddings(token_file: Union[Path, str], token_dim: int) -> torch.T
         The token file loaded as a torch.Tensor.
     """
 
+    # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/uce/uce_utils.py#L56-L56
+    # Reached from dags repo: none (no DAG or bioagents script invokes UCE; only manual example bio-agent/examples/cross_species_integration/README.md)
+    # Pickle written externally: downloaded model artifact from Helical S3 (bucket helicalpackage) key uce/all_tokens.torch (helical/models/uce/uce_config.py:115)
     all_pe = torch.load(token_file)
 
     # TODO: Why this if clause and why this magic number 143574?
@@ -89,6 +92,9 @@ def get_protein_embeddings_idxs(
         A tensor with the indexes of the used genes
     """
     with open(offset_pkl_path, "rb") as f:
+        # [SECURITY CWE-502] Finding: https://github.com/helicalAI/helical/blob/release/helical/models/uce/uce_utils.py#L92-L92
+        # Reached from dags repo: none (no DAG or bioagents script invokes UCE; only manual example bio-agent/examples/cross_species_integration/README.md)
+        # Pickle written externally: downloaded model artifact from Helical S3 (bucket helicalpackage) key uce/species_offsets.pkl (helical/models/uce/uce_config.py:118)
         species_to_offsets = pickle.load(f)
     offset = species_to_offsets[species]
     spec_all_genes = species_to_all_gene_symbols[species]


### PR DESCRIPTION
## What & why

Annotation-only PR for the CWE-502 (unsafe deserialization) scan findings tracked in helicalAI/dashboard#1154. **No executable code is changed** — every added line is a comment; all touched files still compile.

A 3-line block is added directly above each of the **16** flagged `pickle.load` / `pd.read_pickle` / `torch.load` / `pickle.dump` sites in `helical/models/`, recording:

1. **Finding** — the GitHub blob URL of the scan finding.
2. **Reached from dags repo** — which Airflow DAG(s) ultimately invoke the call (DAG → container script → helical function), or `none` with a note on how it is actually run.
3. **Counterpart** — where the pickle is written vs. read (in-repo `path:line`, an external S3/HF artifact, or "no in-repo reader").

> Note: the scan also flagged `blocks.py:452` (`np.load`, `numpy-in-pytorch-modules`). That is a performance lint with no CWE and is not a pickle/deserialization issue, so it is intentionally **not** annotated here.

## Triage summary (from the trace)

- **Live DAG-reachable (prioritise for the fix):** geneformer tokenizer (×3), scgpt, transcriptformer, hyena — all load artifacts downloaded from the `helicalpackage` S3 bucket via `finetuning`/`embedding`/`attention_analysis`/`perturbation`/`evaluation` DAGs (+ nebius finetuning variants).
- **Not reached by any DAG:** all 4 UCE sites, both Tahoe sites, both `base_models` sites (UCE/Tahoe run only via examples/notebooks; `base_models.load_model` is bypassed by bio-agent's own loader).
- **Only pair with an in-repo writer:** `base_models.py:296` (`save_model` → `torch.save`) — cleanest safe-load fix candidate.
- **Dead code:** `geneformer_utils.py:38` writes a pickle nothing reads.

## Verification

- `git diff` confirms only comment lines added, nothing removed.
- `python -m py_compile` passes on all 11 files.
- Every trace (DAG `dag_id`s, container scripts, S3 keys, read/write counterparts) was independently re-verified by adversarial sub-agents against `helical@release` and `dags@develop`.

Refs helicalAI/dashboard#1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)