### PR TITLE
fix(security): harden CWE-502 torch.load sites (weights_only + nosemgrep)

### DIFF
--- a/helical/models/base_models.py
+++ b/helical/models/base_models.py
@@ -323,14 +323,8 @@ class HelicalBaseFineTuningModel(torch.nn.Module):
         except Exception:
             LOGGER.warning(
                 f"State-dict load failed for {path}; "
-                f"attempting to load as a legacy pickle checkpoint. "
-                f"Only load checkpoints from trusted sources (CWE-502)."
+                f"attempting to load as a legacy pickle checkpoint."
             )
-            # Legacy fallback: pre-v2.0.0 full-model pickles (torch.save(model, path)) cannot be
-            # read with weights_only=True. This branch is reached only when the safe load above
-            # fails, and is unpickle-unsafe by nature -- load such checkpoints only from trusted
-            # sources (CWE-502, helicalAI/dashboard#1154).
-            # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
             legacy = torch.load(path, weights_only=False)
             state_dict = legacy.state_dict() if not isinstance(legacy, dict) else legacy
 

--- a/helical/models/base_models.py
+++ b/helical/models/base_models.py
@@ -316,12 +316,21 @@ class HelicalBaseFineTuningModel(torch.nn.Module):
             The path to load the model from.
         """
         try:
+            # Safe: weights_only=True restricts torch.load to tensors/plain types, so a
+            # tampered checkpoint cannot execute arbitrary code (CWE-502, helicalAI/dashboard#1154).
+            # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
             state_dict = torch.load(path, weights_only=True)
         except Exception:
             LOGGER.warning(
                 f"State-dict load failed for {path}; "
-                f"attempting to load as a legacy pickle checkpoint."
+                f"attempting to load as a legacy pickle checkpoint. "
+                f"Only load checkpoints from trusted sources (CWE-502)."
             )
+            # Legacy fallback: pre-v2.0.0 full-model pickles (torch.save(model, path)) cannot be
+            # read with weights_only=True. This branch is reached only when the safe load above
+            # fails, and is unpickle-unsafe by nature -- load such checkpoints only from trusted
+            # sources (CWE-502, helicalAI/dashboard#1154).
+            # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
             legacy = torch.load(path, weights_only=False)
             state_dict = legacy.state_dict() if not isinstance(legacy, dict) else legacy
 

--- a/helical/models/hyena_dna/pretrained_model.py
+++ b/helical/models/hyena_dna/pretrained_model.py
@@ -79,12 +79,6 @@ class HyenaDNAPreTrainedModel(PreTrainedModel):
         scratch_model = HyenaDNAModel(
             **config, use_head=use_head, n_classes=n_classes
         )  # the new model format
-        # weights_only=False is required here: HyenaDNA checkpoints are Lightning-style dicts
-        # that carry non-tensor objects (consumed below as loaded_ckpt["state_dict"]), which
-        # the safe (weights_only=True) loader rejects. The checkpoint is fetched from Helical's
-        # bucket / upstream LongSafari -- load only from trusted sources (CWE-502,
-        # helicalAI/dashboard#1154).
-        # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
         loaded_ckpt = torch.load(
             config["model_path"], map_location=torch.device(device), weights_only=False
         )

--- a/helical/models/hyena_dna/pretrained_model.py
+++ b/helical/models/hyena_dna/pretrained_model.py
@@ -79,6 +79,12 @@ class HyenaDNAPreTrainedModel(PreTrainedModel):
         scratch_model = HyenaDNAModel(
             **config, use_head=use_head, n_classes=n_classes
         )  # the new model format
+        # weights_only=False is required here: HyenaDNA checkpoints are Lightning-style dicts
+        # that carry non-tensor objects (consumed below as loaded_ckpt["state_dict"]), which
+        # the safe (weights_only=True) loader rejects. The checkpoint is fetched from Helical's
+        # bucket / upstream LongSafari -- load only from trusted sources (CWE-502,
+        # helicalAI/dashboard#1154).
+        # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
         loaded_ckpt = torch.load(
             config["model_path"], map_location=torch.device(device), weights_only=False
         )

--- a/helical/models/scgpt/scgpt_utils.py
+++ b/helical/models/scgpt/scgpt_utils.py
@@ -100,7 +100,15 @@ def load_model(model_configs: scGPTConfig):
 
     load_pretrained(
         model,
-        torch.load(model_configs["model_path"], map_location=model_configs["device"]),
+        # weights_only=True restricts torch.load to tensors/plain types (best_model.pt is a
+        # plain state dict), so a tampered checkpoint cannot execute arbitrary code during
+        # unpickling (CWE-502, helicalAI/dashboard#1154).
+        # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
+        torch.load(
+            model_configs["model_path"],
+            map_location=model_configs["device"],
+            weights_only=True,
+        ),
         verbose=False,
     )
     model.to(model_configs["device"])

--- a/helical/models/tahoe/tahoe_x1/model/blocks.py
+++ b/helical/models/tahoe/tahoe_x1/model/blocks.py
@@ -382,6 +382,9 @@ class GeneEncoder(nn.Module):
 
         for name, e_cfg in additional_embedding_cfg.items():
             local_path = e_cfg["local"]
+            # Safe: weights_only=True restricts torch.load to tensors/plain types, so a
+            # tampered checkpoint cannot execute arbitrary code (CWE-502, helicalAI/dashboard#1154).
+            # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
             pretrained_weight = torch.load(local_path, weights_only=True)["embedding.weight"]
             pretrained_vocab_size, pretrained_dim = pretrained_weight.shape
             if pretrained_vocab_size < num_embeddings:

--- a/helical/models/transcriptformer/model.py
+++ b/helical/models/transcriptformer/model.py
@@ -128,6 +128,9 @@ class TranscriptFormer(HelicalRNAModel):
             )
 
         logger.info("Loading model checkpoint")
+        # Safe: weights_only=True restricts torch.load to tensors/plain types, so a
+        # tampered checkpoint cannot execute arbitrary code (CWE-502, helicalAI/dashboard#1154).
+        # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
         state_dict = torch.load(
             self.model.inference_config.load_checkpoint, weights_only=True, map_location=torch.device("cpu")
         )

--- a/helical/models/uce/gene_embeddings.py
+++ b/helical/models/uce/gene_embeddings.py
@@ -65,8 +65,12 @@ def load_gene_embeddings_adata(
     species_to_gene_symbol_to_embedding = {
         species: {
             gene_symbol.lower(): gene_embedding
+            # weights_only=True restricts torch.load to tensors/plain types (the file is a
+            # dict of gene_symbol -> embedding tensor), blocking arbitrary code execution
+            # during unpickling (CWE-502, helicalAI/dashboard#1154).
+            # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
             for gene_symbol, gene_embedding in torch.load(
-                species_to_gene_embedding_path[species]
+                species_to_gene_embedding_path[species], weights_only=True
             ).items()
         }
         for species in species_names
@@ -103,8 +107,12 @@ def load_gene_embeddings_adata(
     species_to_all_gene_symbols = {
         species: [
             gene_symbol.lower()
+            # weights_only=True restricts torch.load to tensors/plain types (the file is a
+            # dict of gene_symbol -> embedding tensor), blocking arbitrary code execution
+            # during unpickling (CWE-502, helicalAI/dashboard#1154).
+            # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
             for gene_symbol, _ in torch.load(
-                species_to_gene_embedding_path[species]
+                species_to_gene_embedding_path[species], weights_only=True
             ).items()
         ]
         for species in species_names

--- a/helical/models/uce/uce_utils.py
+++ b/helical/models/uce/uce_utils.py
@@ -53,7 +53,11 @@ def get_ESM2_embeddings(token_file: Union[Path, str], token_dim: int) -> torch.T
         The token file loaded as a torch.Tensor.
     """
 
-    all_pe = torch.load(token_file)
+    # weights_only=True restricts torch.load to tensors/plain types (all_tokens.torch is a
+    # tensor), so a tampered file cannot execute arbitrary code during unpickling
+    # (CWE-502, helicalAI/dashboard#1154).
+    # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
+    all_pe = torch.load(token_file, weights_only=True)
 
     # TODO: Why this if clause and why this magic number 143574?
     if all_pe.shape[0] == 143574:
@@ -155,7 +159,13 @@ def load_model(
     empty_pe.requires_grad = False
     model.pe_embedding = torch.nn.Embedding.from_pretrained(empty_pe)
     model.load_state_dict(
-        torch.load(model_path, map_location=model_config["device"]), strict=True
+        # weights_only=True restricts torch.load to tensors/plain types (the UCE checkpoint is
+        # a plain state dict), so a tampered checkpoint cannot execute arbitrary code during
+        # unpickling (CWE-502, helicalAI/dashboard#1154). Not in the Bastion CSV, but hardened
+        # here for consistency with the token-file load above.
+        # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
+        torch.load(model_path, map_location=model_config["device"], weights_only=True),
+        strict=True,
     )
 
     # This will make sure that you don't overwrite the tokens in case you're embedding species from the training data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helical"
-version = "2.1.3"
+version = "2.1.4"
 
 authors = [
   { name="Helical Team", email="support@helical-ai.com" },


### PR DESCRIPTION
## What & why

Follow-up to the annotation-only PR #384. This PR **actually mitigates** the CWE-502 (unsafe deserialization) scan findings from helicalAI/dashboard#1154 for the **`torch.load`** sites, and suppresses the Trail of Bits scanner on the sites that are now safe (or unavoidably require full unpickling).

Scope: **Groups A + B (`torch.load`)**. **Group C** (raw `pickle.load` of gene dictionaries — geneformer/uce/transcriptformer/tahoe) is **intentionally deferred** to a follow-up PR and is left untouched here.

## Changes

| Site | Change | Rationale |
|---|---|---|
| `scgpt_utils.py`, `uce_utils.py` (×2), `uce/gene_embeddings.py` (×2) | add `weights_only=True` + `# nosemgrep` | payloads are tensors / plain state dicts; real mitigation |
| `transcriptformer/model.py`, `tahoe/.../blocks.py`, `base_models.py:319` | `# nosemgrep` + justification | already used `weights_only=True`; just clears the scanner |

Notes:
- Under the pinned **torch 2.7.0**, `weights_only` already defaults to `True`, so the added kwargs are **no-ops at runtime** and only harden intent.
- `uce_utils.py:167` (UCE model-weights load) was **missed by the Bastion scan** but hardened here for consistency with the token-file load in the same file.
- Every `# nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch` is placed on the line **immediately preceding** its `torch.load` (Semgrep only honors adjacent suppressions).


## Verification

- **scGPT** and **HyenaDNA** load real downloaded checkpoints end-to-end (dummy instantiation + `test_scgpt_utils.py`/`test_hyena_dna_model.py` pass).
- `python -m py_compile` passes on all 7 touched files.
- CI exercises these load paths against **real, non-mocked** upstream artifacts, so the PR checks will catch any load breakage.

