### PR TITLE
chore(security): add 7-day cooldown to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Wait 7 days before proposing updates to newly published versions so
+    # freshly released (possibly malicious or unstable) packages have time to
+    # be vetted. Security updates are not affected by cooldown.
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## What

Adds a **7-day dependency cooldown** to this repo's dependency-update config, so newly published package versions are not proposed/resolved until they have been available for 7 days. This gives freshly published (possibly malicious or unstable) releases time to be vetted.

## Why

Bastion auto-analysis flagged a missing cooldown (CWE-829: Inclusion of Functionality from Untrusted Control Sphere, HIGH). Security updates are **not** affected by the cooldown.

Refs helicalAI/dashboard#1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnPY71ZEkRpQWSvstkSaP1