### PR TITLE
Updating to `accelerate==1.14.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     'scipy==1.13.1',
     'gitpython==3.1.44',
     'torch==2.7.0',
-    'accelerate==1.13.0',
+    'accelerate==1.14.0',
     'transformers>=4.53.0',
     'loompy==3.0.7',
     'scib==1.1.5',


### PR DESCRIPTION
Reason: [a fix for avoiding double-wrapping in 1.14.0](https://github.com/huggingface/accelerate/blob/v1.14.0-release/src/accelerate/accelerator.py#L2067)