### PR TITLE
fix(hyena_dna): load weights-only checkpoint with weights_only=True

### DIFF
--- a/ci/download_all.py
+++ b/ci/download_all.py
@@ -92,11 +92,11 @@ def main():
 
     download_geneformer_models()
 
-    downloader.download_via_name("hyena_dna/hyenadna-tiny-1k-seqlen.ckpt")
-    downloader.download_via_name("hyena_dna/hyenadna-tiny-1k-seqlen-d256.ckpt")
-    downloader.download_via_name("hyena_dna/hyenadna-small-32k-seqlen.ckpt")
-    downloader.download_via_name("hyena_dna/hyenadna-medium-450k-seqlen.ckpt")
-    downloader.download_via_name("hyena_dna/hyenadna-large-1m-seqlen.ckpt")
+    downloader.download_via_name("hyena_dna/hyenadna-tiny-1k-seqlen.weights.ckpt")
+    downloader.download_via_name("hyena_dna/hyenadna-tiny-1k-seqlen-d256.weights.ckpt")
+    downloader.download_via_name("hyena_dna/hyenadna-small-32k-seqlen.weights.ckpt")
+    downloader.download_via_name("hyena_dna/hyenadna-medium-450k-seqlen.weights.ckpt")
+    downloader.download_via_name("hyena_dna/hyenadna-large-1m-seqlen.weights.ckpt")
 
     downloader.download_via_name(
         "caduceus/caduceus-ph-16L-seqlen-131k-d256/model.safetensors"

--- a/ci/tests/test_hyena_dna/test_hyena_dna_model.py
+++ b/ci/tests/test_hyena_dna/test_hyena_dna_model.py
@@ -21,7 +21,7 @@ def test_hyena_dna__valid_model_names(model_name, d_model, d_inner):
         d_inner (int): The dimensionality of the inner layers.
     """
     configurer = HyenaDNAConfig(model_name=model_name)
-    assert configurer.config["model_path"].name == f"{model_name}.ckpt"
+    assert configurer.config["model_path"].name == f"{model_name}.weights.ckpt"
     assert configurer.config["d_model"] == d_model
     assert configurer.config["d_inner"] == d_inner
 

--- a/helical/models/hyena_dna/hyena_dna_config.py
+++ b/helical/models/hyena_dna/hyena_dna_config.py
@@ -105,11 +105,13 @@ class HyenaDNAConfig:
                 f"Model name {model_name} not found in available models: {self.model_map.keys()}"
             )
 
-        list_of_files_to_download = [f"hyena_dna/{model_name}.ckpt"]
+        list_of_files_to_download = [f"hyena_dna/{model_name}.weights.ckpt"]
 
         self.config = {
             "model_name": model_name,
-            "model_path": Path(CACHE_DIR_HELICAL, f"hyena_dna/{model_name}.ckpt"),
+            "model_path": Path(
+                CACHE_DIR_HELICAL, f"hyena_dna/{model_name}.weights.ckpt"
+            ),
             "list_of_files_to_download": list_of_files_to_download,
             "batch_size": batch_size,
             "d_model": self.model_map[model_name]["d_model"],

--- a/helical/models/hyena_dna/pretrained_model.py
+++ b/helical/models/hyena_dna/pretrained_model.py
@@ -79,8 +79,10 @@ class HyenaDNAPreTrainedModel(PreTrainedModel):
         scratch_model = HyenaDNAModel(
             **config, use_head=use_head, n_classes=n_classes
         )  # the new model format
+        # weights_only=True restricts torch.load to tensors/plain types (the model
+        # file is a tensor-only checkpoint; only ["state_dict"] is used below).
         loaded_ckpt = torch.load(
-            config["model_path"], map_location=torch.device(device), weights_only=False
+            config["model_path"], map_location=torch.device(device), weights_only=True
         )
 
         # need to load weights slightly different if using gradient checkpointing


### PR DESCRIPTION
## Problem

HyenaDNA is the only model still loading its checkpoint with `torch.load(..., weights_only=False)`, which allows arbitrary code execution during unpickling (CWE-502). Every other model (scGPT, UCE, TranscriptFormer, Tahoe) already uses `weights_only=True`.

It couldn't simply flip the flag: the checkpoints hosted on S3 are the **original PyTorch-Lightning training checkpoints**, which pickle non-tensor objects (OmegaConf `DictConfig`/`ListConfig`, an `ABCMeta` class, optimizer/scheduler/loop state). `weights_only=True` rejects those with `UnpicklingError` — a hard crash, not a subtle regression.

## Fix

The code only ever consumes `checkpoint["state_dict"]` (pure tensors). Inference and fine-tuning both start from the weights with a **fresh** optimizer/scheduler, so the training-lifecycle state is entirely unused.

1. Point `HyenaDNAConfig` at a **new** S3 key `hyena_dna/<model>.weights.ckpt` — a slimmed, tensor-only re-save (`{"state_dict": <tensors>}`). The original `.ckpt` is left untouched, so this is fully reversible and older pinned helical versions keep working.
2. Flip the loader to `weights_only=True`.
3. Update `ci/download_all.py` and the config test for the new filename.

The one-off conversion (load full ckpt → keep `state_dict` → re-save) is done offline; the re-saved weights are byte-for-byte identical to the originals (SHA-256 verified). It's not part of the package.

## Scope: all five hosted checkpoints

All five checkpoints hosted on S3 are re-saved as weights-only and referenced from `ci/download_all.py` (`tiny-1k`, `tiny-1k-d256`, `small-32k`, `medium-450k`, `large-1m`). Note: only the two tiny variants are currently exposed via `HyenaDNAConfig.model_map` (i.e. loadable via `from_pretrained`); the larger ones are hosted so the artifacts exist if they're added to `model_map` later.

## Why there is no regression

- `checkpoint["state_dict"]` is the only thing read anywhere in the hyena_dna path (verified).
- Fine-tuning builds a fresh optimizer + scheduler; it never resumes from checkpoint optimizer state.
- Re-saved weights are byte-for-byte identical (SHA-256 verified). Files also shrink (unused optimizer state dropped).
- No other download/load sites for the checkpoint exist in helical, bio-agent, or bio-utils.

## ⚠️ Required before merge/release

The `.weights.ckpt` files must be uploaded to the `helicalpackage` S3 bucket first (new key `hyena_dna/<model>.weights.ckpt`, do **not** overwrite the originals). Until then `Downloader.download_via_name` will fail and HyenaDNA will not load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
