### PR TITLE
Merge main into release: torch 2.10 / CUDA 13 / py3.12 + transformers v5 security floor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,13 +15,20 @@ jobs:
       - name: setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          python-version: 3.11.8
+          python-version: "3.12.13"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
 
       - name: Install dependencies
         run: |
-            pip install .[mamba-ssm]
-            pip install -r requirements-dev.txt
-            
+            uv venv --python "$(command -v python)" "$RUNNER_TEMP/venv"
+            echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
+            echo "VIRTUAL_ENV=$RUNNER_TEMP/venv" >> "$GITHUB_ENV"
+            source "$RUNNER_TEMP/venv/bin/activate"
+            uv pip install .[dev]
+            uv pip install -r requirements_cuda.txt
+
       # First download before tests as they make use of the downloaded files 
       - name: Download all files
         run: |
@@ -49,12 +56,20 @@ jobs:
       - name: setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          python-version: 3.11.8
+          python-version: "3.12.13"
 
       # because jobs may not be run in the same order, we need to install the dependencies again
+      - name: Setup uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+
       - name: Install helical
         run: |
-            pip install .[mamba-ssm]
+            uv venv --python "$(command -v python)" "$RUNNER_TEMP/venv"
+            echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
+            echo "VIRTUAL_ENV=$RUNNER_TEMP/venv" >> "$GITHUB_ENV"
+            source "$RUNNER_TEMP/venv/bin/activate"
+            uv pip install .
+            uv pip install -r requirements_cuda.txt
         
       # Required to get the data
       - name: Download all files
@@ -163,12 +178,19 @@ jobs:
       - name: setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          python-version: 3.11.8
+          python-version: "3.12.13"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
 
       - name: Install helical with flash_attn
         run: |
-            pip install .[mamba-ssm]
-            pip install flash-attn --no-build-isolation
+            uv venv --python "$(command -v python)" "$RUNNER_TEMP/venv"
+            echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
+            echo "VIRTUAL_ENV=$RUNNER_TEMP/venv" >> "$GITHUB_ENV"
+            source "$RUNNER_TEMP/venv/bin/activate"
+            uv pip install .
+            uv pip install -r requirements_cuda.txt
 
       - name: Smoke-test Geneformer (FA2 regression guard)
         run: |
@@ -193,12 +215,20 @@ jobs:
       - name: setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          python-version: 3.11.8
+          python-version: "3.12.13"
 
       # because jobs may not be run in the same order, we need to install the dependencies again
+      - name: Setup uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+
       - name: Install helical
         run: |
-            pip install --no-cache-dir .[mamba-ssm]
+            uv venv --python "$(command -v python)" "$RUNNER_TEMP/venv"
+            echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
+            echo "VIRTUAL_ENV=$RUNNER_TEMP/venv" >> "$GITHUB_ENV"
+            source "$RUNNER_TEMP/venv/bin/activate"
+            uv pip install .[dev]
+            uv pip install -r requirements_cuda.txt
         
       - name: Reduce datasets to speedup checks
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          python-version: 3.11.8
+          python-version: "3.12.13"
       # Do not install mamba-ssm as it is not supported for machines without GPUs
       - name: Install dependencies
         run: |
@@ -33,13 +33,20 @@ jobs:
       - name: setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          python-version: 3.11.8
+          python-version: "3.12.13"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
 
       - name: Install dependencies
         run: |
-            pip install -r requirements-dev.txt
-            pip install .[mamba-ssm]
-            
+            uv venv --python "$(command -v python)" "$RUNNER_TEMP/venv"
+            echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
+            echo "VIRTUAL_ENV=$RUNNER_TEMP/venv" >> "$GITHUB_ENV"
+            source "$RUNNER_TEMP/venv/bin/activate"
+            uv pip install .[dev]
+            uv pip install -r requirements_cuda.txt
+
       # First download before tests as they make use of the downloaded files 
       - name: Download all files
         run: |
@@ -67,12 +74,20 @@ jobs:
       - name: setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          python-version: 3.11.8
+          python-version: "3.12.13"
 
       # because jobs may not be run in the same order, we need to install the dependencies again
+      - name: Setup uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+
       - name: Install helical
         run: |
-            pip install .[mamba-ssm]
+            uv venv --python "$(command -v python)" "$RUNNER_TEMP/venv"
+            echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
+            echo "VIRTUAL_ENV=$RUNNER_TEMP/venv" >> "$GITHUB_ENV"
+            source "$RUNNER_TEMP/venv/bin/activate"
+            uv pip install .
+            uv pip install -r requirements_cuda.txt
         
       # Required to get the data
       - name: Download all files
@@ -181,12 +196,19 @@ jobs:
       - name: setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          python-version: 3.11.8
+          python-version: "3.12.13"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
 
       - name: Install helical with flash_attn
         run: |
-            pip install .[mamba-ssm]
-            pip install flash-attn --no-build-isolation
+            uv venv --python "$(command -v python)" "$RUNNER_TEMP/venv"
+            echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
+            echo "VIRTUAL_ENV=$RUNNER_TEMP/venv" >> "$GITHUB_ENV"
+            source "$RUNNER_TEMP/venv/bin/activate"
+            uv pip install .
+            uv pip install -r requirements_cuda.txt
 
       - name: Smoke-test Geneformer (FA2 regression guard)
         run: |
@@ -211,13 +233,21 @@ jobs:
       - name: setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          python-version: 3.11.8
+          python-version: "3.12.13"
 
       # because jobs may not be run in the same order, we need to install the dependencies again
+      - name: Setup uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+
       - name: Install helical
         run: |
-            pip install .[mamba-ssm]
-                    
+            uv venv --python "$(command -v python)" "$RUNNER_TEMP/venv"
+            echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
+            echo "VIRTUAL_ENV=$RUNNER_TEMP/venv" >> "$GITHUB_ENV"
+            source "$RUNNER_TEMP/venv/bin/activate"
+            uv pip install .[dev]
+            uv pip install -r requirements_cuda.txt
+
       - name: Reduce datasets to speedup checks
         run: |
           sed -i 's/train\[:65%\]/train\[:5%\]/g' ./examples/notebooks/Cell-Type-Annotation.ipynb
@@ -243,7 +273,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          python-version: 3.11.8
+          python-version: "3.12.13"
 
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.5.0-cuda12.4-cudnn9-runtime
+FROM pytorch/pytorch:2.10.0-cuda13.0-cudnn9-runtime
 
 RUN apt-get update -y \
     && apt-get upgrade -y \

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Check out our <a href="https://www.helical-ai.com/blog/helix-mrna-v0" target="_b
 
 We recommend installing Helical within a conda environment with the commands below (run them in your terminal) - this step is optional:
 ```
-conda create --name helical-package python=3.11.13
+conda create --name helical-package python=3.12.13
 conda activate helical-package
 ```
 
@@ -73,7 +73,7 @@ pip install helical
 ***Note***
 Sometimes Torch is not installed as the CUDA compiled version (e.g. on different architectures) which is why you need to manually install Helical with GPU support, run the command below (or install pytorch with cuda first and then install helical):
 ```
-pip install helical --extra-index-url https://download.pytorch.org/whl/cuXXX (replace XXX with your cuda version, e.g. 128 for cuda 12.8)
+pip install helical --extra-index-url https://download.pytorch.org/whl/cuXXX (replace XXX with your cuda version, e.g. 130 for cuda 13.0)
 ```
 
 To install the latest Helical package, you can run the command below:
@@ -104,6 +104,20 @@ or in case you're installing from the Helical repo cloned locally:
 ```
 pip install .[mamba-ssm]
 ```
+
+As a no-compile alternative on CUDA 13 / torch 2.10 / Python 3.12 (Linux x86_64),
+install the prebuilt accelerator wheels (mamba-ssm, causal-conv1d, flash-attn) on
+top of helical:
+```
+pip install .
+pip install -r requirements_cuda.txt
+```
+
+### Development Installation
+To install the test and lint tooling (pytest, pytest-cov, pytest-mock, nbmake, black), use the `dev` extra:
+```
+pip install .[dev]
+```
 ###Evo2 Model Installation
 To install Evo2 Specifically, follow the instructions in the [evo-2 model card](helical/models/evo_2/README.md).
 
@@ -116,11 +130,14 @@ pip install helical[tahoe]
 ## Notes on the installation: 
 - Make sure your machine has GPU(s) and Cuda installed. Currently this is a requirement for the packages mamba-ssm and causal-conv1d. 
 - The package `causal_conv1d` requires `torch` to be installed already. First installing `helical` separately (without `[mamba-ssm]`) will install `torch` for you. A second installation (with `[mamba-ssm]`), installs the packages correctly.
-- If you have problems installing `mamba-ssm`, you can install the package via the provided `.whl` files on their release page [here](https://github.com/state-spaces/mamba/releases/tag/v2.2.4). Choose the package according to your cuda, torch and python version:
+- If you have problems building `mamba-ssm` from source, install the prebuilt `.whl` files instead. The set matching this release (CUDA 13 / torch 2.10 / Python 3.12, Linux x86_64) is pinned in [`requirements_cuda.txt`](./requirements_cuda.txt):
 ```
-pip install https://github.com/state-spaces/mamba/releases/download/v2.2.4/mamba_ssm-2.2.4+cu12torch2.3cxx11abiFALSE-cp311-cp311-linux_x86_64.whl
+pip install -r requirements_cuda.txt
 ```
-- Now continue with `pip install .[mamba-ssm]` to also install the remaining `causal-conv1d`.
+Choose a different wheel from the [mamba releases page](https://github.com/state-spaces/mamba/releases) if your cuda / torch / python version differs, e.g.:
+```
+pip install https://github.com/state-spaces/mamba/releases/download/v2.3.2.post1/mamba_ssm-2.3.2.post1+cu13torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
+```
 
 ### Singularity (Optional)
 If you desire to run your code in a singularity file, you can use the [singularity.def](./singularity.def) file and build an apptainer with it:

--- a/ci/tests/test_evo2/test_evo2_model.py
+++ b/ci/tests/test_evo2/test_evo2_model.py
@@ -17,7 +17,6 @@ torch.manual_seed(1)
 torch.cuda.manual_seed(1)
 
 
-@pytest.mark.skipif(evo2_unavailable, reason="No Evo 2 module present")
 @pytest.fixture
 def read_prompts() -> Union[List[List[str]]]:
     """Read prompts from input file."""
@@ -32,7 +31,6 @@ def read_prompts() -> Union[List[List[str]]]:
     return promptseqs
 
 
-@pytest.mark.skipif(evo2_unavailable, reason="No Evo 2 module present")
 @pytest.fixture
 def evo2_model():
     """Initialize Evo2 model."""
@@ -41,7 +39,6 @@ def evo2_model():
     return model
 
 
-@pytest.mark.skipif(evo2_unavailable, reason="No Evo 2 module present")
 @pytest.fixture
 def test_forward_pass(evo2_model, read_prompts):
     """Test model forward pass accuracy on sequences."""

--- a/examples/notebooks/Hyena-DNA-Inference.ipynb
+++ b/examples/notebooks/Hyena-DNA-Inference.ipynb
@@ -93,21 +93,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Filter: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 461850/461850 [00:00<00:00, 477649.20 examples/s]\n",
-      "Filter: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 48797/48797 [00:00<00:00, 492263.67 examples/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "from datasets import load_dataset\nlabel = \"promoter_tata\"\n\ndataset = load_dataset(\"InstaDeepAI/nucleotide_transformer_downstream_tasks_revised\", \"promoter_tata\")"
-   ]
+   "outputs": [],
+   "source": "from datasets import load_dataset\nlabel = \"promoter_tata\"\n\ndataset = load_dataset(\"InstaDeepAI/nucleotide_transformer_downstream_tasks_revised\", data_dir=label)"
   },
   {
    "cell_type": "markdown",
@@ -118,25 +107,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Nucleotide sequence: CGCTCCCCCA ...\n",
-      "Label name: default and value: 0\n",
-      "Number of classes: 2\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"Nucleotide sequence:\", dataset[\"train\"][\"sequence\"][0][:10], \"...\")\n",
-    "print(\"Label name:\", dataset[\"train\"].config_name, \"and value:\", dataset[\"train\"][\"label\"][0])\n",
-    "num_classes = len(set(dataset[\"train\"][\"label\"]))\n",
-    "print(\"Number of classes:\", num_classes)"
-   ]
+   "outputs": [],
+   "source": "print(\"Nucleotide sequence:\", dataset[\"train\"][\"sequence\"][0][:10], \"...\")\nprint(\"Label name:\", label, \"and value:\", dataset[\"train\"][\"label\"][0])\nnum_classes = len(set(dataset[\"train\"][\"label\"]))\nprint(\"Number of classes:\", num_classes)"
   },
   {
    "cell_type": "markdown",
@@ -206,7 +180,7 @@
      "text": [
       "INFO:helical.models.hyena_dna.model:Succesfully prepared the HyenaDNA Dataset.\n",
       "INFO:helical.models.hyena_dna.model:Started getting embeddings:\n",
-      "Getting embeddings: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1102/1102 [00:03<00:00, 337.42it/s]\n",
+      "Getting embeddings: 100%|██████████| 1102/1102 [00:03<00:00, 337.42it/s]\n",
       "INFO:helical.models.hyena_dna.model:Finished getting embeddings.\n"
      ]
     }
@@ -449,7 +423,7 @@
       "INFO:helical.models.hyena_dna.model:Processing data for HyenaDNA.\n",
       "INFO:helical.models.hyena_dna.model:Succesfully prepared the HyenaDNA Dataset.\n",
       "INFO:helical.models.hyena_dna.model:Started getting embeddings:\n",
-      "Getting embeddings: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 125/125 [00:00<00:00, 439.64it/s]\n",
+      "Getting embeddings: 100%|██████████| 125/125 [00:00<00:00, 439.64it/s]\n",
       "INFO:helical.models.hyena_dna.model:Finished getting embeddings.\n"
      ]
     }
@@ -680,7 +654,7 @@
        "\n",
        "#sk-container-id-1 label.sk-toggleable__label-arrow:before {\n",
        "  /* Arrow on the left of the label */\n",
-       "  content: \"\u25b8\";\n",
+       "  content: \"▸\";\n",
        "  float: left;\n",
        "  margin-right: 0.25em;\n",
        "  color: var(--sklearn-color-icon);\n",
@@ -725,7 +699,7 @@
        "}\n",
        "\n",
        "#sk-container-id-1 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {\n",
-       "  content: \"\u25be\";\n",
+       "  content: \"▾\";\n",
        "}\n",
        "\n",
        "/* Pipeline/ColumnTransformer-specific style */\n",

--- a/examples/notebooks/HyenaDNA-Fine-Tuning.ipynb
+++ b/examples/notebooks/HyenaDNA-Fine-Tuning.ipynb
@@ -94,9 +94,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "label = \"promoter_tata\"\n\ndataset = load_dataset(\"InstaDeepAI/nucleotide_transformer_downstream_tasks_revised\", \"promoter_tata\")\ndataset_train = dataset[\"train\"]\ndataset_test = dataset[\"test\"]"
-   ]
+   "source": "label = \"promoter_tata\"\n\ndataset = load_dataset(\"InstaDeepAI/nucleotide_transformer_downstream_tasks_revised\", data_dir=label)\ndataset_train = dataset[\"train\"]\ndataset_test = dataset[\"test\"]"
   },
   {
    "cell_type": "code",
@@ -180,8 +178,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processing sequences: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 5062/5062 [00:00<00:00, 10775.16it/s]\n",
-      "Processing sequences: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 212/212 [00:00<00:00, 9641.03it/s]\n"
+      "Processing sequences: 100%|██████████| 5062/5062 [00:00<00:00, 10775.16it/s]\n",
+      "Processing sequences: 100%|██████████| 212/212 [00:00<00:00, 9641.03it/s]\n"
      ]
     }
    ],
@@ -213,26 +211,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Fine-Tuning: epoch 1/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 191.25it/s, loss=0.654]\n",
-      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 729.64it/s, val_loss=0.602]\n",
-      "Fine-Tuning: epoch 2/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 213.34it/s, loss=0.441]\n",
-      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 717.45it/s, val_loss=0.796]\n",
-      "Fine-Tuning: epoch 3/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 211.52it/s, loss=0.453]\n",
-      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 716.82it/s, val_loss=0.597]\n",
-      "Fine-Tuning: epoch 4/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 206.29it/s, loss=0.444]\n",
-      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 730.15it/s, val_loss=0.492]\n",
-      "Fine-Tuning: epoch 5/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 232.99it/s, loss=0.439]\n",
-      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 724.66it/s, val_loss=0.424]\n",
-      "Fine-Tuning: epoch 6/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:01<00:00, 256.32it/s, loss=0.438]\n",
-      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 724.62it/s, val_loss=0.382]\n",
-      "Fine-Tuning: epoch 7/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:01<00:00, 258.73it/s, loss=0.436]\n",
-      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 715.60it/s, val_loss=0.351]\n",
-      "Fine-Tuning: epoch 8/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 233.66it/s, loss=0.434]\n",
-      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 709.78it/s, val_loss=0.336]\n",
-      "Fine-Tuning: epoch 9/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 240.10it/s, loss=0.432]\n",
-      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 714.25it/s, val_loss=0.328]\n",
-      "Fine-Tuning: epoch 10/10: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 507/507 [00:02<00:00, 234.96it/s, loss=0.428]\n",
-      "Fine-Tuning Validation: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 716.93it/s, val_loss=0.324]\n"
+      "Fine-Tuning: epoch 1/10: 100%|██████████| 507/507 [00:02<00:00, 191.25it/s, loss=0.654]\n",
+      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 729.64it/s, val_loss=0.602]\n",
+      "Fine-Tuning: epoch 2/10: 100%|██████████| 507/507 [00:02<00:00, 213.34it/s, loss=0.441]\n",
+      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 717.45it/s, val_loss=0.796]\n",
+      "Fine-Tuning: epoch 3/10: 100%|██████████| 507/507 [00:02<00:00, 211.52it/s, loss=0.453]\n",
+      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 716.82it/s, val_loss=0.597]\n",
+      "Fine-Tuning: epoch 4/10: 100%|██████████| 507/507 [00:02<00:00, 206.29it/s, loss=0.444]\n",
+      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 730.15it/s, val_loss=0.492]\n",
+      "Fine-Tuning: epoch 5/10: 100%|██████████| 507/507 [00:02<00:00, 232.99it/s, loss=0.439]\n",
+      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 724.66it/s, val_loss=0.424]\n",
+      "Fine-Tuning: epoch 6/10: 100%|██████████| 507/507 [00:01<00:00, 256.32it/s, loss=0.438]\n",
+      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 724.62it/s, val_loss=0.382]\n",
+      "Fine-Tuning: epoch 7/10: 100%|██████████| 507/507 [00:01<00:00, 258.73it/s, loss=0.436]\n",
+      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 715.60it/s, val_loss=0.351]\n",
+      "Fine-Tuning: epoch 8/10: 100%|██████████| 507/507 [00:02<00:00, 233.66it/s, loss=0.434]\n",
+      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 709.78it/s, val_loss=0.336]\n",
+      "Fine-Tuning: epoch 9/10: 100%|██████████| 507/507 [00:02<00:00, 240.10it/s, loss=0.432]\n",
+      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 714.25it/s, val_loss=0.328]\n",
+      "Fine-Tuning: epoch 10/10: 100%|██████████| 507/507 [00:02<00:00, 234.96it/s, loss=0.428]\n",
+      "Fine-Tuning Validation: 100%|██████████| 22/22 [00:00<00:00, 716.93it/s, val_loss=0.324]\n"
      ]
     }
    ],
@@ -263,7 +261,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 22/22 [00:00<00:00, 782.08it/s]\n"
+      "100%|██████████| 22/22 [00:00<00:00, 782.08it/s]\n"
      ]
     }
    ],

--- a/helical/models/hyena_dna/standalone_hyenadna.py
+++ b/helical/models/hyena_dna/standalone_hyenadna.py
@@ -31,7 +31,9 @@ import json
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Union
 
-from transformers.tokenization_utils import AddedToken, PreTrainedTokenizer
+# Import from the public top-level namespace: the internal
+# `transformers.tokenization_utils` path is removed/reorganized in v5.
+from transformers import AddedToken, PreTrainedTokenizer
 
 
 """# HyenaDNA

--- a/helical/models/tahoe/tahoe_x1/minimal_llm_foundry/grouped_query_attention.py
+++ b/helical/models/tahoe/tahoe_x1/minimal_llm_foundry/grouped_query_attention.py
@@ -437,12 +437,14 @@ class GroupedQueryAttention(nn.Module):
                 # This is done to fix pipeline parallel generation using hf.generate. Please see this comment for details: https://github.com/mosaicml/llm-foundry/pull/1332#issue-2386827204
                 cos = cos.to(query.device)
                 sin = sin.to(query.device)
+                # `position_ids` was deprecated/unused on this path since 4.38
+                # and is removed entirely in transformers 5.x; omitting it keeps
+                # this call working on both 4.53+ and 5.x.
                 query, key = apply_rotary_pos_emb(
                     q=query,
                     k=key,
                     cos=cos,
                     sin=sin,
-                    position_ids=None,
                     unsqueeze_dim=2,
                 )
             elif is_transformers_version_gte('4.36'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helical"
-version = "2.2.0"
+version = "3.0.0"
 
 authors = [
   { name="Helical Team", email="support@helical-ai.com" },
 ]
 description = "Helical Python SDK"
 readme = "README.md"
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.12,<3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
@@ -27,29 +27,49 @@ dependencies = [
     'numpy>=2.1.3,<2.3',  # scipy 1.13.1 requires numpy<2.3
     'scikit-learn>=1.5.0',
     'scipy==1.13.1',
-    'gitpython==3.1.44',
-    'torch==2.7.0',
+    # Pinned exact: prebuilt flash-attn/mamba/causal-conv1d wheels only reach
+    # torch 2.10, and only as cu13+cp312 builds. Bump deliberately (needs new
+    # accelerator wheels + matching CUDA 13 / Python 3.12), not incidentally.
+    'torch==2.10.0',
     'accelerate==1.14.0',
-    'transformers>=4.53.0',
-    'loompy==3.0.7',
-    'scib==1.1.5',
+    'transformers>=5.3.0',  # security floor: clears CVE-2026-4372 (fixed 5.3.0)
     'scikit-misc>=0.5.2',
     'einops==0.8.1',
     'omegaconf==2.3.0',
     'hydra-core==1.3.2',
-    'louvain==0.8.2',
     'pybiomart',
     'datasets==3.6.0',
     'sentencepiece>=0.2.0',
     'bitsandbytes>=0.48.2',
+    # Directly imported by helical but previously only satisfied transitively
+    # (scanpy via scib, now removed) or by a dirty CI env. Declared explicitly so
+    # a clean install has them: scanpy (scgpt/c2s/uce/tahoe model code),
+    # requests-cache (utils/downloader.py, used by every model), torchmetrics +
+    # catalogue (tahoe backbone).
+    'scanpy>=1.11',
+    'requests-cache>=1.2',
+    'torchmetrics>=1.0',
+    'catalogue>=2.0',
+]
+
+constraint-dependencies = [
+    # version-floor guard against the protobuf-3.20 break — removing it loses that floor
     'protobuf>=3.20.0',
 ]
 
-
 [project.optional-dependencies]
+# Test/lint tooling (formerly requirements-dev.txt). Install with `.[dev]`.
+dev = [
+    'pytest==9.0.3',
+    'pytest-cov==7.1.0',
+    'pytest-mock==3.15.1',
+    'nbmake==1.5.4',
+    'black==26.3.1',
+]
+
 mamba-ssm = [
-    'mamba-ssm==2.2.5',
-    'causal-conv1d==1.5.1',
+    'mamba-ssm==2.3.2.post1',
+    'causal-conv1d==1.6.2.post1',
 ]
 
 evo-2 = [
@@ -59,6 +79,22 @@ evo-2 = [
 
 [tool.hatch.metadata]
 allow-direct-references = true # Allows installing package from git
+
+# Default PyPI torch==2.10.0 is a cu12 build (pins cuda-bindings==12.9.4), which
+# collides with the cu13 RAPIDS/cuda-python stack. Pull torch from the cu130
+# index so it resolves to its CUDA 13 build (cuda-bindings 13.x); the nvidia
+# index supplies the cu13 nvidia-*/cuda-bindings deps that build pulls in.
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
+explicit = true
+
+[[tool.uv.index]]
+name = "nvidia"
+url = "https://pypi.nvidia.com"
+
+[tool.uv.sources]
+torch = { index = "pytorch-cu130" }
 
 [project.urls]
 Homepage = "https://github.com/helicalAI/helical"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
-pytest==8.2.0
-pytest-cov==5.0.0
-pytest-mock==3.14.0
-nbmake==1.5.4
-black==26.3.1
-

--- a/requirements_cuda.txt
+++ b/requirements_cuda.txt
@@ -1,6 +1,19 @@
+# Prebuilt CUDA 13 / torch 2.10 / CPython 3.12 accelerator wheels (Linux x86_64).
+#
+# These are direct wheel URLs, so they CANNOT live in pyproject.toml: helical is
+# published to PyPI, and PyPI rejects any distribution whose metadata carries a
+# direct-reference dependency ("Can't have direct dependency: ..."), including
+# inside optional-dependencies/extras. Keep them here and install on top of an
+# existing helical install:
+#
+#   pip install .                      # or: pip install helical
+#   pip install -r requirements_cuda.txt
+#
+# This is the no-compile alternative to `pip install .[mamba-ssm]` (which builds
+# mamba-ssm/causal-conv1d from source). torch 2.10 must already be installed so
+# the ABI (cu13/torch2.10/cp312) matches.
 --extra-index-url https://pypi.nvidia.com
-# rapids-singlecell[rapids12]
-https://github.com/state-spaces/mamba/releases/download/v2.2.5/mamba_ssm-2.2.5+cu12torch2.7cxx11abiFALSE-cp311-cp311-linux_x86_64.whl
-https://github.com/Dao-AILab/causal-conv1d/releases/download/v1.5.1/causal_conv1d-1.5.1+cu12torch2.7cxx11abiFALSE-cp311-cp311-linux_x86_64.whl
-https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/flash_attn-2.7.4.post1+cu12torch2.7cxx11abiFALSE-cp311-cp311-linux_x86_64.whl
-
+# rapids-singlecell-cu13[rapids]>=0.15.0
+https://github.com/state-spaces/mamba/releases/download/v2.3.2.post1/mamba_ssm-2.3.2.post1+cu13torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
+https://github.com/Dao-AILab/causal-conv1d/releases/download/v1.6.2.post1/causal_conv1d-1.6.2.post1+cu13torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
+https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu13torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl


### PR DESCRIPTION
Promote the torch 2.10 / CUDA 13 / Python 3.12 migration and transformers>=5.3.0 security floor (PR #394) from main to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)