### PR TITLE
fix(security): annotate CWE-502 torch.load pickle sites (#1154)

### DIFF
--- a/helical/models/base_models.py
+++ b/helical/models/base_models.py
@@ -325,6 +325,13 @@ class HelicalBaseFineTuningModel(torch.nn.Module):
                 f"State-dict load failed for {path}; "
                 f"attempting to load as a legacy pickle checkpoint."
             )
+            # Reached whenever the strict weights_only=True load above fails. Normally that means
+            # a pre-v2.0.0 checkpoint saved with torch.save(self.model, path) (a full-model pickle
+            # the safe loader cannot read); current save_model writes a state dict that never hits
+            # this path. A corrupt or maliciously-crafted .pt can also fail the safe load and reach
+            # here, and weights_only=False unpickling then carries a CWE-502 arbitrary-code-
+            # execution risk, so only ever call load_model on checkpoints you trust.
+            # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
             legacy = torch.load(path, weights_only=False)
             state_dict = legacy.state_dict() if not isinstance(legacy, dict) else legacy
 

--- a/helical/models/base_models.py
+++ b/helical/models/base_models.py
@@ -331,6 +331,7 @@ class HelicalBaseFineTuningModel(torch.nn.Module):
             # this path. A corrupt or maliciously-crafted .pt can also fail the safe load and reach
             # here, and weights_only=False unpickling then carries a CWE-502 arbitrary-code-
             # execution risk, so only ever call load_model on checkpoints you trust.
+            # TODO: to remove this execution path on October 2026
             # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
             legacy = torch.load(path, weights_only=False)
             state_dict = legacy.state_dict() if not isinstance(legacy, dict) else legacy

--- a/helical/models/hyena_dna/pretrained_model.py
+++ b/helical/models/hyena_dna/pretrained_model.py
@@ -79,8 +79,10 @@ class HyenaDNAPreTrainedModel(PreTrainedModel):
         scratch_model = HyenaDNAModel(
             **config, use_head=use_head, n_classes=n_classes
         )  # the new model format
-        # weights_only=True restricts torch.load to tensors/plain types (the model
-        # file is a tensor-only checkpoint; only ["state_dict"] is used below).
+        # Safe: weights_only=True restricts torch.load to tensors/plain types, so a
+        # tampered checkpoint cannot execute arbitrary code (CWE-502, helicalAI/dashboard#1154).
+        # The model file is a tensor-only checkpoint; only ["state_dict"] is used below.
+        # nosemgrep: trailofbits.python.pickles-in-pytorch.pickles-in-pytorch
         loaded_ckpt = torch.load(
             config["model_path"], map_location=torch.device(device), weights_only=True
         )


### PR DESCRIPTION
## What

Resolves the two remaining `trailofbits.python.pickles-in-pytorch` (CWE-502) semgrep findings from the Bastion analysis by annotating the two `torch.load` sites and documenting why each is acceptable. **No behavior change — comment/annotation-only.**

### 1. `hyena_dna/pretrained_model.py` — false positive
Already loads with `weights_only=True` (tensor-only checkpoint; only `["state_dict"]` is used). Added the `nosemgrep` annotation and a justifying comment.

### 2. `base_models.py` — documented backward-compat fallback
The `weights_only=False` call is the `except` fallback that loads **pre-v2.0.0 full-model pickle checkpoints** (old `save_model` did `torch.save(self.model, path)`, shipped in v1.0.0–v1.12.x). It's reached only when the strict `weights_only=True` load fails. Kept for backward compatibility per decision on the issue; added `nosemgrep` plus a comment documenting the residual risk — the branch also catches corrupt/malicious files, so **only trusted checkpoints should be loaded**.

## Context

All 7 fine-tuning models inherit this `save_model`/`load_model` (none override it), and current `save_model` writes a plain state dict, so `weights_only=True` always succeeds for checkpoints produced by current code. The `weights_only=False` branch is dead for current checkpoints and lives only for v1.x backward compat.

## Testing

Comment/annotation-only; `py_compile` clean. No runtime surface changed, so existing fine-tuning save/load tests are unaffected.

Refs: helicalAI/dashboard#1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSLSjrA4gPK35MGEnfXPgJ