### PR TITLE
fix(security): move nosemgrep annotation onto np.load call in tahoe blocks

### DIFF
--- a/helical/models/tahoe/tahoe_x1/model/blocks.py
+++ b/helical/models/tahoe/tahoe_x1/model/blocks.py
@@ -454,8 +454,8 @@ class ChemEncoder(nn.Module):
             # Safe: np.load only runs once at construction to read a .npy fingerprint
             # file into a tensor; it is not part of forward() and does not affect ONNX
             # tracing or runtime efficiency (helicalAI/dashboard#1154).
-            # nosemgrep: trailofbits.python.numpy-in-pytorch-modules.numpy-in-pytorch-modules
             drug_fps = torch.as_tensor(
+                # nosemgrep: trailofbits.python.numpy-in-pytorch-modules.numpy-in-pytorch-modules
                 np.load(drug_fps_path),
                 dtype=torch.float32,
             )


### PR DESCRIPTION
## Summary
Moves the trailofbits `numpy-in-pytorch-modules` nosemgrep suppression comment directly onto the `np.load(...)` line in `ChemEncoder` so it annotates the actual flagged call rather than the `torch.as_tensor(...)` wrapper.

## Details
Semgrep's line-level suppression must sit on the line containing the flagged expression. Previously the `# nosemgrep` comment preceded the `torch.as_tensor(` call, which is not the numpy operation being flagged. This change places it immediately above `np.load(drug_fps_path)`, keeping the existing explanatory comment (helicalAI/dashboard#1154) intact.

No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)