### PR TITLE
chore: bump helical patch version to 3.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helical"
-version = "3.0.2"
+version = "3.0.3"
 
 authors = [
   { name="Helical Team", email="support@helical-ai.com" },


### PR DESCRIPTION
Bumps the `helical` package patch version `3.0.2` → `3.0.3` in `pyproject.toml`.

Follow-up to #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)