### PR TITLE
Release: nosemgrep fix (#406) + bump to 3.0.3 (#407)

### DIFF
--- a/helical/models/tahoe/tahoe_x1/model/blocks.py
+++ b/helical/models/tahoe/tahoe_x1/model/blocks.py
@@ -454,8 +454,8 @@ class ChemEncoder(nn.Module):
             # Safe: np.load only runs once at construction to read a .npy fingerprint
             # file into a tensor; it is not part of forward() and does not affect ONNX
             # tracing or runtime efficiency (helicalAI/dashboard#1154).
-            # nosemgrep: trailofbits.python.numpy-in-pytorch-modules.numpy-in-pytorch-modules
             drug_fps = torch.as_tensor(
+                # nosemgrep: trailofbits.python.numpy-in-pytorch-modules.numpy-in-pytorch-modules
                 np.load(drug_fps_path),
                 dtype=torch.float32,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helical"
-version = "3.0.2"
+version = "3.0.3"
 
 authors = [
   { name="Helical Team", email="support@helical-ai.com" },


### PR DESCRIPTION
Promotes `main` → `release`.

Includes:
- #406 — fix(security): move nosemgrep annotation onto np.load call in tahoe blocks
- #407 — chore: bump helical patch version 3.0.2 → 3.0.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)