### PR TITLE
chore(ci): Dependabot docker ecosystem + digest-pinned base images (SOC 2 patch mgmt)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,16 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+
+  # Weekly Docker base-image patch PRs — SOC 2 patch management (helicalAI/dashboard#1147).
+  # Base images are digest-pinned in the Dockerfiles, so Dependabot proposes updated
+  # digests (OS security patches) on the same tag — a reviewable, timestamped audit trail.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.10.0-cuda13.0-cudnn9-runtime
+FROM pytorch/pytorch:2.10.0-cuda13.0-cudnn9-runtime@sha256:1f57418aedd9a4d0d3a59646619e1d4f82cacc33817247cead4f749e1f452d4b
 
 RUN apt-get update -y \
     && apt-get upgrade -y \


### PR DESCRIPTION
## SOC 2 Type 2 — Patch Management (Refs helicalAI/dashboard#1147)

Applies the patch-management approach from helicalAI/dashboard#1147 to this repo.

### What changed
- **Added the `docker` package-ecosystem** to `.github/dependabot.yml` (weekly). Previously Dependabot tracked only `github-actions`, so there were **zero** automated base-image patch PRs.
- **Digest-pinned upstream public base images** (`FROM tag` → `FROM tag@sha256:…`) so Dependabot proposes updated *digests* (OS security patches) on the same tag — a timestamped, reviewable audit trail, which is exactly the evidence the control requires.

### Scope / non-goals
- Internal private-ECR images and `ARG BASE_IMAGE` references are intentionally left unpinned — they are patched by rebuilding their source images, not by Dependabot.
- Base-image *major* tag bumps stay a deliberate manual decision (`ignore: version-update:semver-major`); only patch-level digest updates flow automatically.
- `helical/models/evo_2/Dockerfile` (upstream `pytorch:2.6.0…`) is left out of scope: it is a manual/dev model image, not CI-built or deployed to ECR, so it is not part of the patch-management evidence.

### Validation
- `dependabot.yml` parses and declares the `docker` ecosystem.
- Every pinned `image@digest` resolves against its registry.
- `docker buildx --check` lint clean; representative full multi-stage builds pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq1PNsbWEigva8KCxZXVNz
