### PR TITLE
chore(dependabot): add PR assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       - "bputzeys"
       - "jonAtHelical"
       - "priyankvyas"
+      - "dmiv-helical"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     # be vetted. Security updates are not affected by cooldown.
     cooldown:
       default-days: 7
+    assignees:
+      - "oriolpetithelical"
+      - "BrianNejati"
+      - "bputzeys"
+      - "jonAtHelical"
+      - "priyankvyas"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## What
Add a team assignee list to the Dependabot config so update PRs are automatically assigned.

## Why
Assignees make sure these PRs aren't missed. (No Docker ecosystem block in this repo, so the patch-only base-image policy applied in the Docker-enabled repos doesn't apply here.)