### PR TITLE
Fix Dependabot assignee login for Brian

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       default-days: 7
     assignees:
       - "oriolpetithelical"
-      - "BrianNejati"
+      - "briannejati"
       - "bputzeys"
       - "jonAtHelical"
       - "priyankvyas"


### PR DESCRIPTION
## What
Correct the Dependabot assignee login for Brian from `BrianNejati` to `briannejati`.

## Why
The previous value did not match Brian's actual GitHub login (`briannejati`), so Dependabot could not assign PRs correctly. Verified via the GitHub API that `briannejati` is the valid login.