### PR TITLE
fix(genept): make the Ensembl to gene-symbol mapping reachable

### DIFF
--- a/ci/tests/test_genept/test_genept_gene_ids.py
+++ b/ci/tests/test_genept/test_genept_gene_ids.py
@@ -1,0 +1,93 @@
+"""GenePT's gene-identifier handling.
+
+GenePT's embedding table is keyed on **gene symbols** (`get_text_embeddings` looks
+up `self.embeddings.get(emb.upper())` over `var_names`), so Ensembl gene IDs have
+to be mapped *to* symbols -- the opposite direction from the Ensembl-keyed models.
+
+The guard used to read `if gene_names == "ensembl_id":`, copied from Geneformer
+where the correct comparison is `!=`. That made `map_ensembl_ids_to_gene_symbols`
+unreachable on every input where it would have been correct, and there was no
+test directory for GenePT at all, so nothing caught it (bio-agent#1117).
+
+`GenePT.__new__` is used to skip `__init__`, which would download the embedding
+table; `process_data` needs no instance state beyond the inherited validity check.
+"""
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from anndata import AnnData
+
+from helical.models.genept import GenePT
+
+# Real human genes, so the static hsapiens_pybiomart.csv table resolves them.
+TP53, ACTB, GAPDH = "ENSG00000141510", "ENSG00000075624", "ENSG00000111640"
+# In the mapping table, but with a blank symbol.
+NO_SYMBOL = "ENSG00000159239"
+UNKNOWN = "ENSG99999999999"
+
+
+@pytest.fixture
+def model():
+    return GenePT.__new__(GenePT)
+
+
+# process_data runs highly_variable_genes(flavor="seurat_v3"), whose loess fit
+# segfaults on a handful of genes. Pad every fixture out to a workable size with
+# symbol-shaped filler, which the mapping leaves untouched. n_top_genes defaults
+# above this count, so every gene stays "highly variable" and the assertions below
+# are about the mapping, not about HVG selection.
+_PAD_TO = 60
+
+
+def _adata(gene_ids, n_cells=20, filler="FILLER{i}"):
+    padded = list(gene_ids) + [
+        filler.format(i=i) for i in range(max(0, _PAD_TO - len(gene_ids)))
+    ]
+    rng = np.random.default_rng(0)
+    counts = rng.integers(1, 50, size=(n_cells, len(padded))).astype(np.float32)
+    adata = AnnData(X=sp.csr_matrix(counts))
+    adata.var_names = padded
+    return adata
+
+
+class TestGenePTGeneIdentifiers:
+    def test_ensembl_ids_are_mapped_to_symbols(self, model):
+        processed = model.process_data(_adata([TP53, ACTB, GAPDH]))
+        assert {"TP53", "ACTB", "GAPDH"} <= set(processed.var_names)
+        assert not any(str(g).startswith("ENSG") for g in processed.var_names)
+
+    def test_symbols_are_left_untouched(self, model):
+        processed = model.process_data(_adata(["TP53", "ACTB", "GAPDH"]))
+        assert {"TP53", "ACTB", "GAPDH"} <= set(processed.var_names)
+
+    def test_mixed_index_keeps_its_symbols(self, model):
+        # Regression guard for a `.startswith("ENS").any()` + wholesale-remap fix:
+        # that would map the symbols to NaN and drop them.
+        processed = model.process_data(_adata([TP53, "ACTB", GAPDH]))
+        assert "ACTB" in set(processed.var_names)
+
+    def test_symbol_beginning_with_ens_is_not_treated_as_an_ensembl_id(self, model):
+        # ENSA is a real gene symbol; an unanchored `startswith("ENS")` check maps
+        # it to NaN and drops it.
+        processed = model.process_data(_adata(["ENSA", "TP53", "ACTB", "GAPDH"]))
+        assert "ENSA" in set(processed.var_names)
+
+    def test_version_suffixed_ids_are_mapped(self, model):
+        processed = model.process_data(_adata([f"{TP53}.17", f"{ACTB}.9", GAPDH]))
+        assert not any(str(g).startswith("ENSG") for g in processed.var_names)
+
+    def test_ids_without_a_symbol_are_dropped(self, model):
+        processed = model.process_data(_adata([TP53, ACTB, GAPDH, NO_SYMBOL]))
+        assert NO_SYMBOL not in set(processed.var_names)
+
+    def test_raises_when_nothing_maps(self, model):
+        # Filler is unmappable Ensembl IDs too, so genuinely nothing resolves.
+        with pytest.raises(ValueError, match="None of the Ensembl IDs"):
+            model.process_data(_adata([UNKNOWN], filler="ENSG9999999{i:04d}"))
+
+    def test_gene_names_column_is_honoured(self, model):
+        adata = _adata(["g1", "g2", "g3"])
+        adata.var["my_ids"] = [TP53, ACTB, GAPDH] + list(adata.var_names[3:])
+        processed = model.process_data(adata, gene_names="my_ids")
+        assert not any(str(g).startswith("ENSG") for g in processed.var_names)

--- a/ci/tests/test_genept/test_genept_gene_ids.py
+++ b/ci/tests/test_genept/test_genept_gene_ids.py
@@ -25,6 +25,8 @@ TP53, ACTB, GAPDH = "ENSG00000141510", "ENSG00000075624", "ENSG00000111640"
 # In the mapping table, but with a blank symbol.
 NO_SYMBOL = "ENSG00000159239"
 UNKNOWN = "ENSG99999999999"
+# Two distinct Ensembl IDs that both map to the symbol PRPF31.
+PRPF31_A, PRPF31_B = "ENSG00000274144", "ENSG00000105618"
 
 
 @pytest.fixture
@@ -74,8 +76,45 @@ class TestGenePTGeneIdentifiers:
         assert "ENSA" in set(processed.var_names)
 
     def test_version_suffixed_ids_are_mapped(self, model):
+        # Must name the expected symbols: asserting only "no ENSG prefixes remain"
+        # is satisfied just as well by *dropping* the versioned genes, which is
+        # exactly what happened before the version suffix was stripped before
+        # lookup. Versioned IDs are the GENCODE/CellRanger default.
         processed = model.process_data(_adata([f"{TP53}.17", f"{ACTB}.9", GAPDH]))
+        assert {"TP53", "ACTB", "GAPDH"} <= set(processed.var_names)
         assert not any(str(g).startswith("ENSG") for g in processed.var_names)
+
+    def test_ids_colliding_on_one_symbol_are_collapsed(self, model):
+        # Ensembl -> symbol is many-to-one (10616 of 48698 symbol-bearing rows in
+        # hsapiens_pybiomart.csv share a gene_name). Both of these map to PRPF31;
+        # without collapsing, the var index is non-unique and process_data's own
+        # `adata[:, genes_names]` raises InvalidIndexError.
+        processed = model.process_data(_adata([PRPF31_A, PRPF31_B, GAPDH]))
+        assert list(processed.var_names).count("PRPF31") == 1
+        assert processed.var_names.is_unique
+
+    @pytest.mark.parametrize("silent_copy", [0, 1], ids=["first", "second"])
+    def test_collision_keeps_the_expressed_copy(self, model, silent_copy):
+        """Of a colliding set, the copy carrying the counts must win.
+
+        Parametrised over *which* copy is silent, because that is the whole
+        point: picking positionally passes for one arrangement and fails for the
+        other, letting an all-zero alt-scaffold copy displace the expressed gene
+        and report a real gene as unexpressed. Asserted as "the surviving column
+        is non-zero" rather than against raw counts, since process_data applies
+        normalize_total/log1p afterwards -- but log1p(0) is still 0, so a silent
+        survivor would register.
+        """
+        adata = _adata([PRPF31_A, PRPF31_B, GAPDH])
+        dense = adata.X.toarray()
+        dense[:, silent_copy] = 0
+        adata.X = sp.csr_matrix(dense)
+
+        processed = model.process_data(adata)
+        column = list(processed.var_names).index("PRPF31")
+        kept = processed[:, column].X
+        kept = kept.toarray() if sp.issparse(kept) else kept
+        assert kept.sum() > 0, "the silent duplicate displaced the expressed copy"
 
     def test_ids_without_a_symbol_are_dropped(self, model):
         processed = model.process_data(_adata([TP53, ACTB, GAPDH, NO_SYMBOL]))
@@ -87,7 +126,10 @@ class TestGenePTGeneIdentifiers:
             model.process_data(_adata([UNKNOWN], filler="ENSG9999999{i:04d}"))
 
     def test_gene_names_column_is_honoured(self, model):
+        # Must assert the symbols appear: the fixture's own index holds no ENSG
+        # values, so "no ENSG prefixes remain" holds whether or not `my_ids` was
+        # ever read -- gating the mapping on `gene_names == "index"` passed it.
         adata = _adata(["g1", "g2", "g3"])
         adata.var["my_ids"] = [TP53, ACTB, GAPDH] + list(adata.var_names[3:])
         processed = model.process_data(adata, gene_names="my_ids")
-        assert not any(str(g).startswith("ENSG") for g in processed.var_names)
+        assert {"TP53", "ACTB", "GAPDH"} <= set(processed.var_names)

--- a/helical/models/genept/model.py
+++ b/helical/models/genept/model.py
@@ -4,7 +4,7 @@ import numpy as np
 from anndata import AnnData
 from helical.utils.downloader import Downloader
 from helical.models.genept.genept_config import GenePTConfig
-from helical.utils.mapping import map_ensembl_ids_to_gene_symbols
+from helical.utils.mapping import convert_list_ensembl_ids_to_gene_symbols
 import scanpy as sc
 import torch
 import json
@@ -93,14 +93,54 @@ class GenePT(HelicalRNAModel):
         # `.startswith("ENS")`, which also matches real gene symbols (ENSA) and
         # transcript/protein IDs (ENST.., ENSP..), and rather than `.all()`, which
         # would skip a var index that is only mostly Ensembl IDs.
-        identifiers = adata.var[gene_names]
+        identifiers = adata.var[gene_names].astype(str)
         is_ensembl = identifiers.str.match(_ENSEMBL_GENE_ID_PATTERN).fillna(False)
         if is_ensembl.any():
-            mapped = map_ensembl_ids_to_gene_symbols(adata.copy(), gene_names)
-            # Only the Ensembl entries are replaced; anything already a symbol is
+            # The mapping table is keyed on bare gene IDs, so the version suffix
+            # the pattern above accepts has to come off before lookup -- versioned
+            # IDs (ENSG00000141510.17) are the GENCODE/CellRanger default, and
+            # looking them up verbatim resolves nothing. Only Ensembl entries are
+            # stripped: real gene symbols contain dots too (AC000068.10).
+            bare = identifiers.str.split(".").str[0].where(is_ensembl, identifiers)
+            to_convert = sorted(set(bare[is_ensembl]))
+            symbols = convert_list_ensembl_ids_to_gene_symbols(to_convert)
+            # Excludes unmapped ids rather than keeping a None value, so no entry
+            # can later resolve through a bogus key.
+            mapping = {
+                ensembl_id: symbol
+                for ensembl_id, symbol in zip(to_convert, symbols)
+                if symbol
+            }
+            # Ensembl entries become their symbol; anything already a symbol is
             # kept as-is, so a mixed var index does not lose its symbols.
-            resolved = mapped.var["gene_names"].where(is_ensembl, identifiers)
-            keep = resolved.notnull().to_numpy()
+            resolved = [
+                mapping.get(bare_id) if flag else original
+                for bare_id, flag, original in zip(bare, is_ensembl, identifiers)
+            ]
+
+            # Ensembl -> symbol is many-to-one: 10616 of the 48698 symbol-bearing
+            # rows in hsapiens_pybiomart.csv share a gene_name (3369 symbols
+            # carried by >=2 ids, e.g. PRPF31, 5S_rRNA, Y_RNA). Without collapsing
+            # them the var index comes out non-unique and the `adata[:, genes_names]`
+            # subset below raises InvalidIndexError. Of a colliding set keep the
+            # copy carrying the most counts, so an all-zero alt-scaffold copy can
+            # never displace the expressed one (which picking positionally would).
+            totals = np.asarray(adata.X.sum(axis=0)).ravel()
+            best_for_symbol: dict = {}
+            for index, symbol in enumerate(resolved):
+                if symbol is None:
+                    continue
+                incumbent = best_for_symbol.get(symbol)
+                if incumbent is None or totals[index] > totals[incumbent]:
+                    best_for_symbol[symbol] = index
+            kept_indices = set(best_for_symbol.values())
+            keep = np.array(
+                [
+                    symbol is not None and index in kept_indices
+                    for index, symbol in enumerate(resolved)
+                ]
+            )
+
             if not keep.any():
                 message = (
                     "None of the Ensembl IDs could be mapped to gene symbols, which "
@@ -109,14 +149,18 @@ class GenePT(HelicalRNAModel):
                 )
                 LOGGER.error(message)
                 raise ValueError(message)
-            n_dropped = int((~keep).sum())
-            if n_dropped:
+
+            n_unmapped = sum(1 for symbol in resolved if symbol is None)
+            n_duplicate = int((~keep).sum()) - n_unmapped
+            if n_unmapped or n_duplicate:
                 LOGGER.info(
-                    f"Mapped Ensembl IDs to gene symbols for GenePT; dropped "
-                    f"{n_dropped} gene(s) with no symbol."
+                    f"Mapped Ensembl IDs to gene symbols for GenePT: "
+                    f"{len(resolved)} gene(s) in -> {int(keep.sum())} out "
+                    f"({n_unmapped} dropped with no symbol, "
+                    f"{n_duplicate} dropped as duplicate symbols)."
                 )
             adata = adata[:, keep].copy()
-            adata.var_names = resolved[keep].values
+            adata.var_names = [symbol for symbol, kept in zip(resolved, keep) if kept]
 
         sc.pp.highly_variable_genes(adata, flavor="seurat_v3")
         sc.pp.normalize_total(adata, target_sum=1e4)

--- a/helical/models/genept/model.py
+++ b/helical/models/genept/model.py
@@ -11,6 +11,9 @@ import json
 
 LOGGER = logging.getLogger(__name__)
 
+# Ensembl gene IDs, optionally version-suffixed (ENSG00000141510.17).
+_ENSEMBL_GENE_ID_PATTERN = r"^ENS[A-Z]{0,4}G\d{11}(\.\d+)?$"
+
 
 class GenePT(HelicalRNAModel):
     """GenePT Model.
@@ -56,19 +59,17 @@ class GenePT(HelicalRNAModel):
         Parameters
         ----------
         adata : AnnData
-            The AnnData object containing the data to be processed. GenePT uses Ensembl IDs to identify genes
-            and currently supports only human genes. If the AnnData object already has an 'ensembl_id' column,
-            the mapping step can be skipped.
+            The AnnData object containing the data to be processed. GenePT identifies genes by
+            **gene symbol** -- its embedding table is keyed on symbols (see `get_text_embeddings`)
+            -- and currently supports only human genes. Ensembl gene IDs are mapped to symbols
+            automatically.
         gene_names : str, optional, default="index"
-            The column in `adata.var` that contains the gene names. If set to a value other than "ensembl_id",
-            the gene symbols in that column will be mapped to Ensembl IDs using the 'pyensembl' package,
-            which retrieves mappings from the Ensembl FTP server and loads them into a local database.
-            - If set to "index", the index of the AnnData object will be used and mapped to Ensembl IDs.
-            - If set to "ensembl_id", no mapping will occur.
-            Special case:
-                If the index of `adata` already contains Ensembl IDs, setting this to "index" will result in
-                invalid mappings. In such cases, create a new column containing Ensembl IDs and pass "ensembl_id"
-                as the value of `gene_names`.
+            The column in `adata.var` that holds the gene identifiers.
+            - "index" (default): the index of the AnnData object is used.
+            - any other column name: that column is used.
+            Either way, if the identifiers are Ensembl gene IDs they are mapped to gene symbols
+            and `var_names` is set to the result; genes with no symbol are dropped. Identifiers
+            that are already symbols are left untouched.
         use_raw_counts : bool, optional, default=True
             Determines whether raw counts should be used.
 
@@ -80,18 +81,42 @@ class GenePT(HelicalRNAModel):
         LOGGER.info("Processing data for GenePT.")
         self.ensure_rna_data_validity(adata, gene_names, use_raw_counts)
 
-        # map gene symbols to ensemble ids if provided
-        if gene_names == "ensembl_id":
-            if (adata.var[gene_names].str.startswith("ENS").all()) or (
-                adata.var[gene_names].str.startswith("None").any()
-            ):
+        # GenePT's embedding table is keyed on gene symbols, so Ensembl IDs have to
+        # be mapped *to* symbols -- the opposite direction from the Ensembl-keyed
+        # models. This condition used to read `== "ensembl_id"` (copied from
+        # Geneformer, which needs `!=`), which made the mapping unreachable on every
+        # input where it would have been correct: gene_names="ensembl_id" with real
+        # Ensembl IDs raised an error telling the caller to set the flag they had
+        # just set, and the default gene_names="index" skipped mapping altogether
+        # and looked Ensembl IDs up in a symbol-keyed table (bio-agent#1117).
+        # Matched per entry with an anchored Ensembl *gene* ID pattern rather than
+        # `.startswith("ENS")`, which also matches real gene symbols (ENSA) and
+        # transcript/protein IDs (ENST.., ENSP..), and rather than `.all()`, which
+        # would skip a var index that is only mostly Ensembl IDs.
+        identifiers = adata.var[gene_names]
+        is_ensembl = identifiers.str.match(_ENSEMBL_GENE_ID_PATTERN).fillna(False)
+        if is_ensembl.any():
+            mapped = map_ensembl_ids_to_gene_symbols(adata.copy(), gene_names)
+            # Only the Ensembl entries are replaced; anything already a symbol is
+            # kept as-is, so a mixed var index does not lose its symbols.
+            resolved = mapped.var["gene_names"].where(is_ensembl, identifiers)
+            keep = resolved.notnull().to_numpy()
+            if not keep.any():
                 message = (
-                    "It seems an anndata with 'ensemble ids' and/or 'None' was passed. "
-                    "Please set gene_names='ensembl_id' and remove 'None's to skip mapping."
+                    "None of the Ensembl IDs could be mapped to gene symbols, which "
+                    "GenePT's embeddings are keyed on. Please check the gene "
+                    "identifiers in .var of the anndata input object."
                 )
-                LOGGER.info(message)
+                LOGGER.error(message)
                 raise ValueError(message)
-            adata = map_ensembl_ids_to_gene_symbols(adata, gene_names)
+            n_dropped = int((~keep).sum())
+            if n_dropped:
+                LOGGER.info(
+                    f"Mapped Ensembl IDs to gene symbols for GenePT; dropped "
+                    f"{n_dropped} gene(s) with no symbol."
+                )
+            adata = adata[:, keep].copy()
+            adata.var_names = resolved[keep].values
 
         sc.pp.highly_variable_genes(adata, flavor="seurat_v3")
         sc.pp.normalize_total(adata, target_sum=1e4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helical"
-version = "3.0.3"
+version = "3.0.4"
 
 authors = [
   { name="Helical Team", email="support@helical-ai.com" },


### PR DESCRIPTION
Fixes helicalAI/bio-agent#1121. Companion to helicalAI/bio-agent#1127; diagnosis in helicalAI/bio-agent#1117.

## GenePT's Ensembl → symbol mapping was dead code

GenePT's embedding table is keyed on gene **symbols** (`get_text_embeddings` looks up `self.embeddings.get(emb.upper())` over `var_names`), so Ensembl IDs must be mapped *to* symbols — the opposite direction from the Ensembl-keyed models. The guard read:

```python
if gene_names == "ensembl_id":          # '==', not '!='
    if adata.var[gene_names].str.startswith("ENS").all() or ...:
        raise ValueError("... Please set gene_names='ensembl_id' ...")
    adata = map_ensembl_ids_to_gene_symbols(adata, gene_names)
```

copied from Geneformer, where the correct comparison is `!=`. The mapping was therefore unreachable on every input where it would have been correct:

- `gene_names="ensembl_id"` with real Ensembl IDs **raised**, telling the caller to set the flag they had just set;
- `gene_names="ensembl_id"` with non-`ENS` values mapped "Ensembl → symbols" over data that was not Ensembl;
- `gene_names="index"` — the default, and the only value bio-agent can reach, since `FineTuning.predict` calls `process_data(data)` positionally — skipped mapping entirely and looked Ensembl IDs up in a symbol-keyed table.

The docstring was also copied from Geneformer and described the opposite model ("GenePT uses Ensembl IDs to identify genes"). Rewritten to match reality.

## Detection

Per entry against an anchored Ensembl *gene* ID pattern, rather than `.startswith("ENS").all()`. The latter also matches real gene symbols (`ENSA`) and transcript/protein IDs (`ENST…`, `ENSP…`), and `.all()` skips a var index that is only mostly Ensembl IDs. Entries already symbols are preserved, so a mixed index does not lose them.

## Two further defects, caught by committee review and fixed in the second commit

Both were introduced by making the guard reachable — before that, the default path never ran the mapping, so neither was reachable for exactly the inputs this fix exists to serve.

1. **Version-suffixed IDs were silently dropped.** The pattern accepts `(\.\d+)?`, but the matched identifiers went to the mapping table unstripped, and that table is keyed on bare `ENSG…`. Verified: TP53 and ACTB vanished from `[ENSG00000141510.17, ENSG00000075624.9, ENSG00000111640]`, leaving only unversioned GAPDH. Versioned IDs are the GENCODE/CellRanger default. Stripped now, and only for entries matching the Ensembl pattern — real symbols contain dots too (`AC000068.10`).

2. **Duplicate symbols crashed `process_data`.** Ensembl → symbol is many-to-one: 10,616 of the 48,698 symbol-bearing rows in `hsapiens_pybiomart.csv` share a `gene_name` (3,369 symbols carried by ≥2 IDs). A non-unique `var_names` made this function's own `adata[:, genes_names]` raise `InvalidIndexError: Reindexing only valid with uniquely valued Index objects`. Verified with `ENSG00000274144` + `ENSG00000105618` (both → `PRPF31`). Collapsed now to the copy carrying the most counts, so an all-zero alt-scaffold copy cannot displace the expressed one.

Also drops the `adata.copy()`: the helper only reads one `var` column, so `convert_list_ensembl_ids_to_gene_symbols` is called directly — measured 13.9 MB vs 62.1 MB peak on a 4000×3000 float32 AnnData — which additionally removes the coupling to the helper's hardcoded `"gene_names"` output column.

## Tests

`ci/tests/test_genept/` **did not exist** — that is why the inverted guard survived. 11 tests added, covering both identifier systems, mixed indexes, `ENSA`, versioned IDs, symbol-less IDs, collisions, expressed-copy selection, and a non-index `gene_names` column.

Two of them initially passed for the wrong reason and were fixed only after confirming the mutation passed against them: `test_version_suffixed_ids_are_mapped` asserted only that no `ENSG` prefixes remained (which dropping satisfies as well as mapping), and `test_gene_names_column_is_honoured` asserted nothing at all, since the fixture's index holds no `ENSG` values either way.

Mutation-tested: restoring the unreachable guard, remapping wholesale instead of per entry, removing the version strip, positional dedupe, and gating the mapping on `gene_names == "index"` each turn the suite red.

`pytest ci/tests/test_genept ci/tests/test_utils` → 33 passed, 1 skipped. `black` clean. Version bumped 3.0.3 → 3.0.4 (PATCH: bug fix).

## Note on scope

The other four models still use the inlined `.startswith("ENS").all()` check, with the `ENSA`/`ENST` and all-or-nothing weaknesses described above. Unifying them on one detector is tracked separately in helicalAI/bio-agent#1123 — it is a behaviour change across Geneformer, Tahoe, Nicheformer and Transcriptformer, and keeping it out means this correctness fix is not blocked behind it.
