### PR TITLE
feat: handle Ensembl/symbol gene identifiers in each model's process_data

### DIFF
--- a/ci/tests/test_genept/test_genept_gene_ids.py
+++ b/ci/tests/test_genept/test_genept_gene_ids.py
@@ -7,7 +7,7 @@ to be mapped *to* symbols -- the opposite direction from the Ensembl-keyed model
 The guard used to read `if gene_names == "ensembl_id":`, copied from Geneformer
 where the correct comparison is `!=`. That made `map_ensembl_ids_to_gene_symbols`
 unreachable on every input where it would have been correct, and there was no
-test directory for GenePT at all, so nothing caught it (bio-agent#1117).
+test directory for GenePT at all, so nothing caught it.
 
 `GenePT.__new__` is used to skip `__init__`, which would download the embedding
 table; `process_data` needs no instance state beyond the inherited validity check.

--- a/ci/tests/test_genept/test_genept_gene_ids.py
+++ b/ci/tests/test_genept/test_genept_gene_ids.py
@@ -122,7 +122,7 @@ class TestGenePTGeneIdentifiers:
 
     def test_raises_when_nothing_maps(self, model):
         # Filler is unmappable Ensembl IDs too, so genuinely nothing resolves.
-        with pytest.raises(ValueError, match="None of the Ensembl IDs"):
+        with pytest.raises(ValueError, match="could be mapped to gene symbols"):
             model.process_data(_adata([UNKNOWN], filler="ENSG9999999{i:04d}"))
 
     def test_gene_names_column_is_honoured(self, model):

--- a/ci/tests/test_tahoe/test_tahoe_model.py
+++ b/ci/tests/test_tahoe/test_tahoe_model.py
@@ -8,6 +8,7 @@ from anndata import AnnData
 from scipy.sparse import csr_matrix
 
 from helical.models.tahoe import Tahoe, TahoeConfig
+from helical.utils.mapping import ensure_ensembl_ids
 from helical.models.tahoe.tahoe_x1.model import TXModel
 from helical.models.tahoe.tahoe_x1.tokenizer import GeneVocab
 
@@ -138,14 +139,11 @@ class TestTahoeModel:
             tahoe.collator_cfg = {"pad_token_id": 1}
             tahoe.config = {"batch_size": 2}
 
-            # Mock map_gene_symbols_to_ensembl_ids to set all as NaN
-            with patch("helical.models.tahoe.model.map_gene_symbols_to_ensembl_ids") as mock_map:
-                data_copy = data.copy()
-                data_copy.var["ensembl_id"] = [None, None]
-                mock_map.return_value = data_copy
-
-                with pytest.raises(ValueError, match="All gene symbols could not be mapped"):
-                    tahoe.process_data(data, gene_names="gene_symbols")
+            # UNKNOWN1/UNKNOWN2 are genuinely unmappable, so the behaviour under
+            # test needs no mock of an internal helper -- which also means it keeps
+            # working when that helper changes (helicalAI/bio-agent#1122).
+            with pytest.raises(ValueError, match="could be resolved to Ensembl"):
+                tahoe.process_data(data, gene_names="gene_symbols")
 
     def test_state_dict_prefix_removal(self):
         """Test that 'model.' prefix is correctly removed from state dict."""
@@ -284,20 +282,32 @@ class TestTahoeModel:
             with pytest.raises(KeyError):
                 tahoe.ensure_rna_data_validity(data, gene_names="missing_column", use_raw_counts=True)
 
-    def test_gene_mapping_ensembl_warning(self, mocker):
-        """Test warning when ensembl IDs are passed but gene_names != 'ensembl_id'."""
+    def test_ensembl_ids_in_a_named_column_are_used_directly(self):
+        """Ensembl IDs are accepted, not refused.
+
+        This used to assert `pytest.raises(ValueError, match="ensemble ids")`: a
+        column of Ensembl IDs with gene_names != "ensembl_id" was rejected outright,
+        which made an Ensembl-indexed AnnData unusable from any caller that cannot
+        set gene_names. Tahoe's vocabulary *is* Ensembl-keyed, so those identifiers
+        are now used as they are -- deliberately with no symbol round trip, which
+        would drop every gene that has no gene symbol (helicalAI/bio-agent#1122).
+
+        Asserted on the reconciliation rather than the whole pipeline: the old test
+        never reached the rest of `process_data` either, since it always raised
+        first, and the hand-built config here has none of what tokenization needs.
+        """
         data = AnnData(X=csr_matrix(np.array([[1.0, 2.0]])))
         data.var["gene_symbols"] = ["ENSG00000187634", "ENSG00000188290"]
         data.obs["cell_type"] = ["CD4 T cells"]
 
-        with patch.object(Tahoe, "__init__", lambda x, configurer: None):
-            tahoe = Tahoe.__new__(Tahoe)
-            tahoe.vocab = {"ENSG00000187634": 2}
-            tahoe.collator_cfg = {"pad_token_id": 1}
-            tahoe.config = {"batch_size": 2}
+        out = ensure_ensembl_ids(data, "gene_symbols", model="Tahoe")
 
-            with pytest.raises(ValueError, match="ensemble ids"):
-                tahoe.process_data(data, gene_names="gene_symbols")
+        assert list(out.var["ensembl_id"]) == [
+            "ENSG00000187634",
+            "ENSG00000188290",
+        ]
+        # var_names are the caller's, untouched.
+        assert list(out.var_names) == list(data.var_names)
 
 
 class TestTXModelFromHF:

--- a/ci/tests/test_tahoe/test_tahoe_model.py
+++ b/ci/tests/test_tahoe/test_tahoe_model.py
@@ -141,7 +141,7 @@ class TestTahoeModel:
 
             # UNKNOWN1/UNKNOWN2 are genuinely unmappable, so the behaviour under
             # test needs no mock of an internal helper -- which also means it keeps
-            # working when that helper changes (helicalAI/bio-agent#1122).
+            # working when that helper changes.
             with pytest.raises(ValueError, match="could be resolved to Ensembl"):
                 tahoe.process_data(data, gene_names="gene_symbols")
 
@@ -290,7 +290,7 @@ class TestTahoeModel:
         which made an Ensembl-indexed AnnData unusable from any caller that cannot
         set gene_names. Tahoe's vocabulary *is* Ensembl-keyed, so those identifiers
         are now used as they are -- deliberately with no symbol round trip, which
-        would drop every gene that has no gene symbol (helicalAI/bio-agent#1122).
+        would drop every gene that has no gene symbol.
 
         Asserted on the reconciliation rather than the whole pipeline: the old test
         never reached the rest of `process_data` either, since it always raised

--- a/ci/tests/test_tahoe/test_tahoe_model.py
+++ b/ci/tests/test_tahoe/test_tahoe_model.py
@@ -300,7 +300,7 @@ class TestTahoeModel:
         data.var["gene_symbols"] = ["ENSG00000187634", "ENSG00000188290"]
         data.obs["cell_type"] = ["CD4 T cells"]
 
-        out = ensure_ensembl_ids(data, "gene_symbols", model="Tahoe")
+        out = ensure_ensembl_ids(data, "gene_symbols")
 
         assert list(out.var["ensembl_id"]) == [
             "ENSG00000187634",

--- a/ci/tests/test_utils/test_gene_identifiers.py
+++ b/ci/tests/test_utils/test_gene_identifiers.py
@@ -121,6 +121,30 @@ class TestEnsureGeneSymbols:
         column = list(out.var_names).index("PRPF31")
         assert out.X.toarray()[:, column].sum() == expected
 
+    def test_rewrites_var_names_even_when_gene_names_is_a_column(self):
+        # The surprising part, so pinned explicitly: symbol-keyed models disagree
+        # about which identifiers they read -- scGPT reads var[gene_names], GenePT
+        # reads var_names regardless -- so both are normalised. The caller's own
+        # identifiers stay recoverable via original_gene_id.
+        adata = _adata([TP53, ACTB])
+        adata.var_names = ["row0", "row1"]
+        adata.var["my_ids"] = [TP53, ACTB]
+
+        out = ensure_gene_symbols(adata, "my_ids")
+
+        assert list(out.var_names) == ["TP53", "ACTB"]
+        assert list(out.var["my_ids"]) == ["TP53", "ACTB"]
+        assert list(out.var["original_gene_id"]) == [TP53, ACTB]
+
+    def test_leaves_the_callers_object_untouched(self):
+        adata = _adata([TP53, ACTB])
+        before = list(adata.var_names)
+
+        out = ensure_gene_symbols(adata)
+
+        assert out is not adata
+        assert list(adata.var_names) == before
+
     def test_keeps_the_named_column_in_step_with_var_names(self):
         # Callers run ensure_rna_data_validity first, which materialises
         # var["index"] from the pre-conversion index; a lookup reading that column

--- a/ci/tests/test_utils/test_gene_identifiers.py
+++ b/ci/tests/test_utils/test_gene_identifiers.py
@@ -1,0 +1,195 @@
+"""Gene-identifier detection and normalisation primitives (helicalAI/bio-agent#1123).
+
+These replace five inlined copies of `startswith("ENS")` across the models. All
+three of the following were live bugs in that expression, so each has a test here:
+
+- it matches real gene symbols (`ENSA`) and transcript/protein IDs (`ENST…`, `ENSP…`);
+- `.all()`/`.any()` over the column cannot express a var index that is only
+  *mostly* Ensembl IDs;
+- version suffixes are never stripped, so `ENSG…​.17` — the GENCODE/CellRanger
+  default — fails a lookup keyed on bare IDs and the gene is dropped.
+
+Uses the bundled static hsapiens table, so no network access.
+"""
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from anndata import AnnData
+
+from helical.utils.mapping import (
+    ensembl_id_mask,
+    ensure_ensembl_ids,
+    ensure_gene_symbols,
+    is_ensembl_gene_id,
+    reject_null_identifiers,
+    require_vocabulary_overlap,
+    strip_ensembl_version,
+)
+
+TP53, ACTB, GAPDH = "ENSG00000141510", "ENSG00000075624", "ENSG00000111640"
+# In Geneformer's vocabulary, but with a blank gene symbol in the mapping table.
+NO_SYMBOL = "ENSG00000159239"
+# Two distinct Ensembl IDs that both resolve to the symbol PRPF31.
+PRPF31_A, PRPF31_B = "ENSG00000274144", "ENSG00000105618"
+MOUSE = "ENSMUSG00000021033"
+
+
+def _adata(identifiers, n_cells=4):
+    counts = np.random.default_rng(0).integers(1, 50, size=(n_cells, len(identifiers)))
+    adata = AnnData(X=sp.csr_matrix(counts.astype(np.float32)))
+    adata.var_names = list(identifiers)
+    return adata
+
+
+class TestDetection:
+    @pytest.mark.parametrize("value", [TP53, f"{TP53}.17", MOUSE])
+    def test_accepts_gene_ids(self, value):
+        assert is_ensembl_gene_id(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "ENSA",  # a real gene symbol beginning with ENS
+            "ENST00000141510",  # transcript, not gene
+            "ENSP00000141510",  # protein, not gene
+            "TP53",
+            "AC000068.10",  # a symbol containing a dot
+            "ENSG123",  # too few digits
+        ],
+    )
+    def test_rejects_non_gene_ids(self, value):
+        assert not is_ensembl_gene_id(value)
+
+    def test_mask_is_per_entry_not_aggregate(self):
+        # The case neither .all() nor .any() can express.
+        mask = ensembl_id_mask(["TP53", TP53, "ENSA", f"{ACTB}.3"])
+        assert list(mask) == [False, True, False, True]
+
+    @pytest.mark.parametrize("ratio_ensembl", [0.1, 0.5, 0.9])
+    def test_mixed_indexes_at_several_ratios(self, ratio_ensembl):
+        n = 20
+        n_ensembl = int(n * ratio_ensembl)
+        values = [TP53] * n_ensembl + ["TP53"] * (n - n_ensembl)
+        assert ensembl_id_mask(values).sum() == n_ensembl
+
+    def test_strip_version_only_touches_gene_ids(self):
+        assert strip_ensembl_version(f"{TP53}.17") == TP53
+        assert strip_ensembl_version(TP53) == TP53
+        # A real symbol containing a dot must survive intact.
+        assert strip_ensembl_version("AC000068.10") == "AC000068.10"
+
+
+class TestEnsureGeneSymbols:
+    def test_translates_ensembl_to_symbols(self):
+        out = ensure_gene_symbols(_adata([TP53, ACTB, GAPDH]))
+        assert list(out.var_names) == ["TP53", "ACTB", "GAPDH"]
+        assert list(out.var["original_gene_id"]) == [TP53, ACTB, GAPDH]
+
+    def test_is_a_noop_for_symbols(self):
+        adata = _adata(["TP53", "ACTB"])
+        assert ensure_gene_symbols(adata) is adata
+
+    def test_keeps_symbols_in_a_mixed_index(self):
+        out = ensure_gene_symbols(_adata([TP53, "ACTB", "ENSA"]))
+        assert set(out.var_names) == {"TP53", "ACTB", "ENSA"}
+
+    def test_strips_versions_before_lookup(self):
+        out = ensure_gene_symbols(_adata([f"{TP53}.17", f"{ACTB}.9"]))
+        assert list(out.var_names) == ["TP53", "ACTB"]
+
+    def test_drops_ids_with_no_symbol(self):
+        out = ensure_gene_symbols(_adata([TP53, NO_SYMBOL]))
+        assert list(out.var_names) == ["TP53"]
+
+    def test_collapses_colliding_symbols(self):
+        out = ensure_gene_symbols(_adata([PRPF31_A, PRPF31_B, GAPDH]))
+        assert out.var_names.is_unique
+        assert list(out.var_names).count("PRPF31") == 1
+
+    @pytest.mark.parametrize("silent", [0, 1], ids=["first", "second"])
+    def test_collision_keeps_the_expressed_copy(self, silent):
+        # Parametrised over which copy is silent: positional selection passes one
+        # arrangement and fails the other, so one fixture would prove nothing.
+        adata = _adata([PRPF31_A, PRPF31_B, GAPDH])
+        dense = adata.X.toarray()
+        dense[:, silent] = 0
+        expected = dense[:, 1 - silent].sum()
+        adata.X = sp.csr_matrix(dense)
+
+        out = ensure_gene_symbols(adata)
+        column = list(out.var_names).index("PRPF31")
+        assert out.X.toarray()[:, column].sum() == expected
+
+    def test_keeps_the_named_column_in_step_with_var_names(self):
+        # Callers run ensure_rna_data_validity first, which materialises
+        # var["index"] from the pre-conversion index; a lookup reading that column
+        # would otherwise still see the old identifiers.
+        adata = _adata([TP53, ACTB])
+        adata.var["index"] = adata.var_names
+        out = ensure_gene_symbols(adata, "index")
+        assert list(out.var["index"]) == list(out.var_names) == ["TP53", "ACTB"]
+
+    def test_raises_when_nothing_maps(self):
+        with pytest.raises(ValueError, match="could be mapped to gene symbols"):
+            ensure_gene_symbols(_adata(["ENSG99999999999", "ENSG99999999998"]))
+
+
+class TestEnsureEnsemblIds:
+    def test_uses_existing_ensembl_ids_directly(self):
+        # The point of the design: no symbol round trip, so a gene with no symbol
+        # at all still reaches an Ensembl-keyed vocabulary.
+        out = ensure_ensembl_ids(_adata([TP53, NO_SYMBOL]))
+        assert list(out.var["ensembl_id"]) == [TP53, NO_SYMBOL]
+
+    def test_translates_symbols(self):
+        out = ensure_ensembl_ids(_adata(["TP53", "ACTB"]))
+        assert list(out.var["ensembl_id"]) == [TP53, ACTB]
+
+    def test_handles_a_mixed_index(self):
+        out = ensure_ensembl_ids(_adata([TP53, "ACTB"]))
+        assert list(out.var["ensembl_id"]) == [TP53, ACTB]
+
+    def test_strips_versions(self):
+        out = ensure_ensembl_ids(_adata([f"{TP53}.17"]))
+        assert list(out.var["ensembl_id"]) == [TP53]
+
+    def test_unmapped_symbols_become_empty_not_none(self):
+        # A None reaching a dict key or an `in` check is the aliasing trap from
+        # bio-agent#1112; an empty string simply fails the vocabulary lookup.
+        out = ensure_ensembl_ids(_adata(["TP53", "NOT_A_REAL_GENE_XYZ"]))
+        assert list(out.var["ensembl_id"]) == [TP53, ""]
+
+    def test_var_names_are_left_alone(self):
+        # Reverse lookups (id_to_gene) and caller-supplied gene lists address the
+        # caller's own identifiers, so these must not be rewritten.
+        out = ensure_ensembl_ids(_adata(["TP53", "ACTB"]))
+        assert list(out.var_names) == ["TP53", "ACTB"]
+
+    def test_raises_when_nothing_resolves(self):
+        with pytest.raises(ValueError, match="could be resolved to Ensembl"):
+            ensure_ensembl_ids(_adata(["NOT_A_GENE_1", "NOT_A_GENE_2"]))
+
+
+class TestGuards:
+    @pytest.mark.parametrize("sentinel", ["None", "nan", "", "NA", "null"])
+    def test_null_identifiers_are_rejected(self, sentinel):
+        with pytest.raises(ValueError, match="null placeholders"):
+            reject_null_identifiers(["TP53", sentinel])
+
+    def test_real_symbols_starting_with_sentinel_letters_are_fine(self):
+        # Matched exactly, not by prefix: NANOS1 and NAT1 are real genes.
+        reject_null_identifiers(["NANOS1", "NAT1", "NONO"])
+
+    def test_vocabulary_overlap_rejects_another_species(self):
+        # What the removed namespace guards caught by accident: well-formed IDs
+        # from the wrong annotation would otherwise tokenize to nothing, silently.
+        with pytest.raises(ValueError, match="vocabulary"):
+            require_vocabulary_overlap([MOUSE], {TP53: 1, ACTB: 2}, model="test")
+
+    def test_vocabulary_overlap_accepts_a_partial_match(self):
+        require_vocabulary_overlap([MOUSE, TP53], {TP53: 1}, model="test")
+
+    def test_vocabulary_overlap_ignores_unresolved_entries(self):
+        with pytest.raises(ValueError, match="vocabulary"):
+            require_vocabulary_overlap(["", ""], {TP53: 1}, model="test")

--- a/ci/tests/test_utils/test_gene_identifiers.py
+++ b/ci/tests/test_utils/test_gene_identifiers.py
@@ -185,11 +185,11 @@ class TestGuards:
         # What the removed namespace guards caught by accident: well-formed IDs
         # from the wrong annotation would otherwise tokenize to nothing, silently.
         with pytest.raises(ValueError, match="vocabulary"):
-            require_vocabulary_overlap([MOUSE], {TP53: 1, ACTB: 2}, model="test")
+            require_vocabulary_overlap([MOUSE], {TP53: 1, ACTB: 2})
 
     def test_vocabulary_overlap_accepts_a_partial_match(self):
-        require_vocabulary_overlap([MOUSE, TP53], {TP53: 1}, model="test")
+        require_vocabulary_overlap([MOUSE, TP53], {TP53: 1})
 
     def test_vocabulary_overlap_ignores_unresolved_entries(self):
         with pytest.raises(ValueError, match="vocabulary"):
-            require_vocabulary_overlap(["", ""], {TP53: 1}, model="test")
+            require_vocabulary_overlap(["", ""], {TP53: 1})

--- a/ci/tests/test_utils/test_gene_identifiers.py
+++ b/ci/tests/test_utils/test_gene_identifiers.py
@@ -1,4 +1,4 @@
-"""Gene-identifier detection and normalisation primitives (helicalAI/bio-agent#1123).
+"""Gene-identifier detection and normalisation primitives.
 
 These replace five inlined copies of `startswith("ENS")` across the models. All
 three of the following were live bugs in that expression, so each has a test here:
@@ -179,8 +179,9 @@ class TestEnsureEnsemblIds:
         assert list(out.var["ensembl_id"]) == [TP53]
 
     def test_unmapped_symbols_become_empty_not_none(self):
-        # A None reaching a dict key or an `in` check is the aliasing trap from
-        # bio-agent#1112; an empty string simply fails the vocabulary lookup.
+        # A None reaching a dict key or an `in` check silently aliases every
+        # unmapped entry onto one arbitrary gene; an empty string simply fails
+        # the vocabulary lookup.
         out = ensure_ensembl_ids(_adata(["TP53", "NOT_A_REAL_GENE_XYZ"]))
         assert list(out.var["ensembl_id"]) == [TP53, ""]
 

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -190,7 +190,7 @@ class Geneformer(HelicalRNAModel):
         # ENSG00000159239), which a round trip would drop. This used to raise
         # outright whenever every identifier looked Ensembl-like, making an
         # Ensembl-indexed AnnData unusable from any caller that cannot set
-        # gene_names (helicalAI/bio-agent#1117).
+        # gene_names.
         if gene_names != "ensembl_id":
             adata = ensure_ensembl_ids(adata, gene_names)
 

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -9,7 +9,7 @@ from transformers import BertForMaskedLM
 from helical.models.geneformer.geneformer_utils import get_embs, quant_layers
 from helical.models.geneformer.geneformer_tokenizer import TranscriptomeTokenizer
 from helical.models.geneformer.geneformer_config import GeneformerConfig
-from helical.utils.mapping import map_gene_symbols_to_ensembl_ids
+from helical.utils.mapping import ensure_ensembl_ids, require_vocabulary_overlap
 from datasets import Dataset
 from typing import Optional
 
@@ -183,23 +183,23 @@ class Geneformer(HelicalRNAModel):
         """
         LOGGER.info(f"Processing data for Geneformer.")
         self.ensure_rna_data_validity(adata, gene_names, use_raw_counts)
-        # map gene symbols to ensemble ids if provided
+        # Populate var["ensembl_id"] from whichever system the caller used.
+        # Identifiers that are already Ensembl gene IDs are taken directly rather
+        # than round-tripped through symbols: Geneformer's vocabulary is
+        # Ensembl-keyed and contains genes with no gene symbol at all (e.g.
+        # ENSG00000159239), which a round trip would drop. This used to raise
+        # outright whenever every identifier looked Ensembl-like, making an
+        # Ensembl-indexed AnnData unusable from any caller that cannot set
+        # gene_names (helicalAI/bio-agent#1117).
         if gene_names != "ensembl_id":
-            if (adata.var[gene_names].str.startswith("ENS").all()) or (
-                adata.var[gene_names].str.startswith("None").any()
-            ):
-                message = (
-                    "It seems an anndata with 'ensemble ids' and/or 'None' was passed. "
-                    "Please set gene_names='ensembl_id' and remove 'None's to skip mapping."
-                )
-                LOGGER.info(message)
-                raise ValueError(message)
-            adata = map_gene_symbols_to_ensembl_ids(adata, gene_names)
+            adata = ensure_ensembl_ids(adata, gene_names, model="Geneformer")
 
-            if adata.var["ensembl_id"].isnull().all():
-                message = "All gene symbols could not be mapped to Ensembl IDs. Please check the input data."
-                LOGGER.info(message)
-                raise ValueError(message)
+        # Accepting Ensembl input means shape alone no longer tells us the data is
+        # usable, so check vocabulary membership instead -- well-formed IDs from
+        # another species would otherwise tokenize to nothing, silently.
+        require_vocabulary_overlap(
+            adata.var["ensembl_id"], self.tk.gene_token_dict, model="Geneformer"
+        )
 
         tokenized_cells, cell_metadata = self.tk.tokenize_anndata(adata)
         tokenized_dataset = self.tk.create_dataset(

--- a/helical/models/geneformer/model.py
+++ b/helical/models/geneformer/model.py
@@ -192,14 +192,12 @@ class Geneformer(HelicalRNAModel):
         # Ensembl-indexed AnnData unusable from any caller that cannot set
         # gene_names (helicalAI/bio-agent#1117).
         if gene_names != "ensembl_id":
-            adata = ensure_ensembl_ids(adata, gene_names, model="Geneformer")
+            adata = ensure_ensembl_ids(adata, gene_names)
 
         # Accepting Ensembl input means shape alone no longer tells us the data is
         # usable, so check vocabulary membership instead -- well-formed IDs from
         # another species would otherwise tokenize to nothing, silently.
-        require_vocabulary_overlap(
-            adata.var["ensembl_id"], self.tk.gene_token_dict, model="Geneformer"
-        )
+        require_vocabulary_overlap(adata.var["ensembl_id"], self.tk.gene_token_dict)
 
         tokenized_cells, cell_metadata = self.tk.tokenize_anndata(adata)
         tokenized_dataset = self.tk.create_dataset(

--- a/helical/models/genept/model.py
+++ b/helical/models/genept/model.py
@@ -4,15 +4,12 @@ import numpy as np
 from anndata import AnnData
 from helical.utils.downloader import Downloader
 from helical.models.genept.genept_config import GenePTConfig
-from helical.utils.mapping import convert_list_ensembl_ids_to_gene_symbols
+from helical.utils.mapping import ensure_gene_symbols
 import scanpy as sc
 import torch
 import json
 
 LOGGER = logging.getLogger(__name__)
-
-# Ensembl gene IDs, optionally version-suffixed (ENSG00000141510.17).
-_ENSEMBL_GENE_ID_PATTERN = r"^ENS[A-Z]{0,4}G\d{11}(\.\d+)?$"
 
 
 class GenePT(HelicalRNAModel):
@@ -89,78 +86,12 @@ class GenePT(HelicalRNAModel):
         # Ensembl IDs raised an error telling the caller to set the flag they had
         # just set, and the default gene_names="index" skipped mapping altogether
         # and looked Ensembl IDs up in a symbol-keyed table (bio-agent#1117).
-        # Matched per entry with an anchored Ensembl *gene* ID pattern rather than
-        # `.startswith("ENS")`, which also matches real gene symbols (ENSA) and
-        # transcript/protein IDs (ENST.., ENSP..), and rather than `.all()`, which
-        # would skip a var index that is only mostly Ensembl IDs.
-        identifiers = adata.var[gene_names].astype(str)
-        is_ensembl = identifiers.str.match(_ENSEMBL_GENE_ID_PATTERN).fillna(False)
-        if is_ensembl.any():
-            # The mapping table is keyed on bare gene IDs, so the version suffix
-            # the pattern above accepts has to come off before lookup -- versioned
-            # IDs (ENSG00000141510.17) are the GENCODE/CellRanger default, and
-            # looking them up verbatim resolves nothing. Only Ensembl entries are
-            # stripped: real gene symbols contain dots too (AC000068.10).
-            bare = identifiers.str.split(".").str[0].where(is_ensembl, identifiers)
-            to_convert = sorted(set(bare[is_ensembl]))
-            symbols = convert_list_ensembl_ids_to_gene_symbols(to_convert)
-            # Excludes unmapped ids rather than keeping a None value, so no entry
-            # can later resolve through a bogus key.
-            mapping = {
-                ensembl_id: symbol
-                for ensembl_id, symbol in zip(to_convert, symbols)
-                if symbol
-            }
-            # Ensembl entries become their symbol; anything already a symbol is
-            # kept as-is, so a mixed var index does not lose its symbols.
-            resolved = [
-                mapping.get(bare_id) if flag else original
-                for bare_id, flag, original in zip(bare, is_ensembl, identifiers)
-            ]
-
-            # Ensembl -> symbol is many-to-one: 10616 of the 48698 symbol-bearing
-            # rows in hsapiens_pybiomart.csv share a gene_name (3369 symbols
-            # carried by >=2 ids, e.g. PRPF31, 5S_rRNA, Y_RNA). Without collapsing
-            # them the var index comes out non-unique and the `adata[:, genes_names]`
-            # subset below raises InvalidIndexError. Of a colliding set keep the
-            # copy carrying the most counts, so an all-zero alt-scaffold copy can
-            # never displace the expressed one (which picking positionally would).
-            totals = np.asarray(adata.X.sum(axis=0)).ravel()
-            best_for_symbol: dict = {}
-            for index, symbol in enumerate(resolved):
-                if symbol is None:
-                    continue
-                incumbent = best_for_symbol.get(symbol)
-                if incumbent is None or totals[index] > totals[incumbent]:
-                    best_for_symbol[symbol] = index
-            kept_indices = set(best_for_symbol.values())
-            keep = np.array(
-                [
-                    symbol is not None and index in kept_indices
-                    for index, symbol in enumerate(resolved)
-                ]
-            )
-
-            if not keep.any():
-                message = (
-                    "None of the Ensembl IDs could be mapped to gene symbols, which "
-                    "GenePT's embeddings are keyed on. Please check the gene "
-                    "identifiers in .var of the anndata input object."
-                )
-                LOGGER.error(message)
-                raise ValueError(message)
-
-            n_unmapped = sum(1 for symbol in resolved if symbol is None)
-            n_duplicate = int((~keep).sum()) - n_unmapped
-            if n_unmapped or n_duplicate:
-                LOGGER.info(
-                    f"Mapped Ensembl IDs to gene symbols for GenePT: "
-                    f"{len(resolved)} gene(s) in -> {int(keep.sum())} out "
-                    f"({n_unmapped} dropped with no symbol, "
-                    f"{n_duplicate} dropped as duplicate symbols)."
-                )
-            adata = adata[:, keep].copy()
-            adata.var_names = [symbol for symbol, kept in zip(resolved, keep) if kept]
+        # GenePT's embedding table is keyed on gene symbols, so Ensembl IDs must be
+        # mapped *to* symbols -- the opposite direction from the Ensembl-keyed
+        # models. The guard here used to read `== "ensembl_id"` (copied from
+        # Geneformer, which needs `!=`), which made the mapping unreachable on
+        # every input where it would have been correct (helicalAI/bio-agent#1117).
+        adata = ensure_gene_symbols(adata, gene_names, model="GenePT")
 
         sc.pp.highly_variable_genes(adata, flavor="seurat_v3")
         sc.pp.normalize_total(adata, target_sum=1e4)

--- a/helical/models/genept/model.py
+++ b/helical/models/genept/model.py
@@ -91,7 +91,7 @@ class GenePT(HelicalRNAModel):
         # models. The guard here used to read `== "ensembl_id"` (copied from
         # Geneformer, which needs `!=`), which made the mapping unreachable on
         # every input where it would have been correct (helicalAI/bio-agent#1117).
-        adata = ensure_gene_symbols(adata, gene_names, model="GenePT")
+        adata = ensure_gene_symbols(adata, gene_names)
 
         sc.pp.highly_variable_genes(adata, flavor="seurat_v3")
         sc.pp.normalize_total(adata, target_sum=1e4)

--- a/helical/models/genept/model.py
+++ b/helical/models/genept/model.py
@@ -85,12 +85,12 @@ class GenePT(HelicalRNAModel):
         # input where it would have been correct: gene_names="ensembl_id" with real
         # Ensembl IDs raised an error telling the caller to set the flag they had
         # just set, and the default gene_names="index" skipped mapping altogether
-        # and looked Ensembl IDs up in a symbol-keyed table (bio-agent#1117).
+        # and looked Ensembl IDs up in a symbol-keyed table.
         # GenePT's embedding table is keyed on gene symbols, so Ensembl IDs must be
         # mapped *to* symbols -- the opposite direction from the Ensembl-keyed
         # models. The guard here used to read `== "ensembl_id"` (copied from
         # Geneformer, which needs `!=`), which made the mapping unreachable on
-        # every input where it would have been correct (helicalAI/bio-agent#1117).
+        # every input where it would have been correct.
         adata = ensure_gene_symbols(adata, gene_names)
 
         sc.pp.highly_variable_genes(adata, flavor="seurat_v3")

--- a/helical/models/nicheformer/model.py
+++ b/helical/models/nicheformer/model.py
@@ -134,8 +134,7 @@ class Nicheformer(HelicalRNAModel):
             col = adata.var[gene_names]
             # Per entry against an anchored gene-ID pattern: `startswith("ENS")`
             # also matches real symbols (ENSA) and transcript/protein IDs, and
-            # `.all()` skips a var index that is only mostly Ensembl IDs
-            # (helicalAI/bio-agent#1123).
+            # `.all()` skips a var index that is only mostly Ensembl IDs.
             if not ensembl_id_mask(col).all():
                 adata = map_gene_symbols_to_ensembl_ids(
                     adata, gene_names if gene_names != "index" else None

--- a/helical/models/nicheformer/model.py
+++ b/helical/models/nicheformer/model.py
@@ -1,7 +1,7 @@
 from helical.models.base_models import HelicalRNAModel
 from helical.models.nicheformer.nicheformer_config import NicheformerConfig
 from helical.utils.downloader import Downloader
-from helical.utils.mapping import map_gene_symbols_to_ensembl_ids
+from helical.utils.mapping import ensembl_id_mask, map_gene_symbols_to_ensembl_ids
 from anndata import AnnData
 from datasets import Dataset
 from helical.models.nicheformer.modeling_nicheformer import NicheformerForMaskedLM
@@ -132,7 +132,11 @@ class Nicheformer(HelicalRNAModel):
 
         if gene_names != "ensembl_id":
             col = adata.var[gene_names]
-            if not col.str.startswith("ENS").all():
+            # Per entry against an anchored gene-ID pattern: `startswith("ENS")`
+            # also matches real symbols (ENSA) and transcript/protein IDs, and
+            # `.all()` skips a var index that is only mostly Ensembl IDs
+            # (helicalAI/bio-agent#1123).
+            if not ensembl_id_mask(col).all():
                 adata = map_gene_symbols_to_ensembl_ids(
                     adata, gene_names if gene_names != "index" else None
                 )

--- a/helical/models/scgpt/model.py
+++ b/helical/models/scgpt/model.py
@@ -365,9 +365,8 @@ class scGPT(HelicalRNAModel):
         self.ensure_data_validity(adata, gene_names, use_batch_labels, use_raw_counts)
 
         # scGPT's vocabulary is keyed on gene symbols, so an Ensembl-indexed
-        # AnnData used to filter to zero genes and raise below
-        # (helicalAI/bio-agent#1117). Ensembl IDs are translated per entry, so a
-        # symbol-keyed or mixed index is unaffected.
+        # AnnData used to filter to zero genes and raise below. Ensembl IDs are
+        # translated per entry, so a symbol-keyed or mixed index is unaffected.
         adata = ensure_gene_symbols(adata, gene_names)
 
         self.gene_names = gene_names

--- a/helical/models/scgpt/model.py
+++ b/helical/models/scgpt/model.py
@@ -4,6 +4,7 @@ import scanpy as sc
 from helical.models.base_models import HelicalRNAModel
 from helical.models.scgpt.scgpt_config import scGPTConfig
 import numpy as np
+from helical.utils.mapping import ensure_gene_symbols
 import pandas as pd
 from anndata import AnnData
 import logging
@@ -362,6 +363,12 @@ class scGPT(HelicalRNAModel):
 
         LOGGER.info(f"Processing data for scGPT.")
         self.ensure_data_validity(adata, gene_names, use_batch_labels, use_raw_counts)
+
+        # scGPT's vocabulary is keyed on gene symbols, so an Ensembl-indexed
+        # AnnData used to filter to zero genes and raise below
+        # (helicalAI/bio-agent#1117). Ensembl IDs are translated per entry, so a
+        # symbol-keyed or mixed index is unaffected.
+        adata = ensure_gene_symbols(adata, gene_names, model="scGPT")
 
         self.gene_names = gene_names
         if fine_tuning:

--- a/helical/models/scgpt/model.py
+++ b/helical/models/scgpt/model.py
@@ -368,7 +368,7 @@ class scGPT(HelicalRNAModel):
         # AnnData used to filter to zero genes and raise below
         # (helicalAI/bio-agent#1117). Ensembl IDs are translated per entry, so a
         # symbol-keyed or mixed index is unaffected.
-        adata = ensure_gene_symbols(adata, gene_names, model="scGPT")
+        adata = ensure_gene_symbols(adata, gene_names)
 
         self.gene_names = gene_names
         if fine_tuning:

--- a/helical/models/tahoe/model.py
+++ b/helical/models/tahoe/model.py
@@ -143,13 +143,13 @@ class Tahoe(HelicalRNAModel):
         # Geneformer for why Ensembl input is used directly rather than
         # round-tripped through symbols (helicalAI/bio-agent#1117).
         if gene_names != "ensembl_id":
-            adata = ensure_ensembl_ids(adata, gene_names, model="Tahoe")
+            adata = ensure_ensembl_ids(adata, gene_names)
 
         gene_id_key = "ensembl_id"
 
         # Membership, not shape, is what tells us the identifiers are usable now
         # that Ensembl input is accepted.
-        require_vocabulary_overlap(adata.var[gene_id_key], self.vocab, model="Tahoe")
+        require_vocabulary_overlap(adata.var[gene_id_key], self.vocab)
 
         # Map genes to vocabulary
         adata.var["id_in_vocab"] = [

--- a/helical/models/tahoe/model.py
+++ b/helical/models/tahoe/model.py
@@ -141,7 +141,7 @@ class Tahoe(HelicalRNAModel):
 
         # Populate var["ensembl_id"] from whichever system the caller used; see
         # Geneformer for why Ensembl input is used directly rather than
-        # round-tripped through symbols (helicalAI/bio-agent#1117).
+        # round-tripped through symbols.
         if gene_names != "ensembl_id":
             adata = ensure_ensembl_ids(adata, gene_names)
 

--- a/helical/models/tahoe/model.py
+++ b/helical/models/tahoe/model.py
@@ -6,7 +6,7 @@ import torch
 from typing import Union, List
 from torch.utils.data import DataLoader
 from helical.models.tahoe.tahoe_config import TahoeConfig
-from helical.utils.mapping import map_gene_symbols_to_ensembl_ids
+from helical.utils.mapping import ensure_ensembl_ids, require_vocabulary_overlap
 import pandas as pd
 from helical.models.tahoe.tahoe_x1.model import TXModel
 from helical.models.tahoe.tahoe_x1.utils import loader_from_adata
@@ -139,25 +139,17 @@ class Tahoe(HelicalRNAModel):
         LOGGER.info("Processing data for Tahoe.")
         self.ensure_rna_data_validity(adata, gene_names, use_raw_counts)
 
-        # Map gene symbols to Ensembl IDs if provided
+        # Populate var["ensembl_id"] from whichever system the caller used; see
+        # Geneformer for why Ensembl input is used directly rather than
+        # round-tripped through symbols (helicalAI/bio-agent#1117).
         if gene_names != "ensembl_id":
-            if (adata.var[gene_names].str.startswith("ENS").all()) or (
-                adata.var[gene_names].str.startswith("None").any()
-            ):
-                message = (
-                    "It seems an anndata with 'ensemble ids' and/or 'None' was passed. "
-                    "Please set gene_names='ensembl_id' and remove 'None's to skip mapping."
-                )
-                LOGGER.error(message)
-                raise ValueError(message)
-            adata = map_gene_symbols_to_ensembl_ids(adata, gene_names)
-
-            if adata.var["ensembl_id"].isnull().all():
-                message = "All gene symbols could not be mapped to Ensembl IDs. Please check the input data."
-                LOGGER.error(message)
-                raise ValueError(message)
+            adata = ensure_ensembl_ids(adata, gene_names, model="Tahoe")
 
         gene_id_key = "ensembl_id"
+
+        # Membership, not shape, is what tells us the identifiers are usable now
+        # that Ensembl input is accepted.
+        require_vocabulary_overlap(adata.var[gene_id_key], self.vocab, model="Tahoe")
 
         # Map genes to vocabulary
         adata.var["id_in_vocab"] = [

--- a/helical/models/transcriptformer/data/dataloader.py
+++ b/helical/models/transcriptformer/data/dataloader.py
@@ -36,8 +36,7 @@ def load_gene_features(adata, gene_col_name, species: str = "hsapiens"):
         logging.error(message)
         raise ValueError(message)
     # Anchored per-entry check rather than a substring `contains("ENS")`, which
-    # also matches real gene symbols (ENSA) and transcript/protein IDs
-    # (helicalAI/bio-agent#1123).
+    # also matches real gene symbols (ENSA) and transcript/protein IDs.
     if ensembl_id_mask(adata.var[gene_col_name]).mean() <= 0.5:
         adata = map_gene_symbols_to_ensembl_ids(adata, gene_names=gene_col_name, species=species)
         gene_names = np.array(list(adata.var["ensembl_id"].values))

--- a/helical/models/transcriptformer/data/dataloader.py
+++ b/helical/models/transcriptformer/data/dataloader.py
@@ -9,7 +9,7 @@ import torch
 from scipy.sparse import csc_matrix, csr_matrix
 from torch import tensor
 from torch.utils.data import Dataset
-from helical.utils.mapping import map_gene_symbols_to_ensembl_ids
+from helical.utils.mapping import ensembl_id_mask, map_gene_symbols_to_ensembl_ids
 from helical.models.transcriptformer.data.dataclasses import BatchData
 from helical.models.transcriptformer.tokenizer.tokenizer import (
     BatchGeneTokenizer,
@@ -35,7 +35,10 @@ def load_gene_features(adata, gene_col_name, species: str = "hsapiens"):
         message = f"Gene column '{gene_col_name}' not found in adata.var.columns. Available columns: {adata.var.columns}. Modify config accordingly."
         logging.error(message)
         raise ValueError(message)
-    if adata.var[gene_col_name].str.contains("ENS", na=False).mean() <= 0.5:
+    # Anchored per-entry check rather than a substring `contains("ENS")`, which
+    # also matches real gene symbols (ENSA) and transcript/protein IDs
+    # (helicalAI/bio-agent#1123).
+    if ensembl_id_mask(adata.var[gene_col_name]).mean() <= 0.5:
         adata = map_gene_symbols_to_ensembl_ids(adata, gene_names=gene_col_name, species=species)
         gene_names = np.array(list(adata.var["ensembl_id"].values))
     else:

--- a/helical/models/uce/model.py
+++ b/helical/models/uce/model.py
@@ -132,7 +132,7 @@ class UCE(HelicalRNAModel):
         # UCE looks genes up by symbol in its protein-embedding table, so an
         # Ensembl-indexed AnnData matched nothing and hit the "no matching genes"
         # error in gene_embeddings.py (helicalAI/bio-agent#1117).
-        adata = ensure_gene_symbols(adata, gene_names, model="UCE")
+        adata = ensure_gene_symbols(adata, gene_names)
 
         if gene_names != "index":
             adata.var.index = adata.var[gene_names]

--- a/helical/models/uce/model.py
+++ b/helical/models/uce/model.py
@@ -9,6 +9,7 @@ import torch
 from accelerate import Accelerator
 from helical.models.uce.uce_config import UCEConfig
 from helical.models.base_models import HelicalRNAModel
+from helical.utils.mapping import ensure_gene_symbols
 from helical.models.uce.uce_utils import (
     get_ESM2_embeddings,
     get_positions,
@@ -127,6 +128,11 @@ class UCE(HelicalRNAModel):
 
         LOGGER.info(f"Processing data for UCE.")
         self.ensure_rna_data_validity(adata, gene_names, use_raw_counts)
+
+        # UCE looks genes up by symbol in its protein-embedding table, so an
+        # Ensembl-indexed AnnData matched nothing and hit the "no matching genes"
+        # error in gene_embeddings.py (helicalAI/bio-agent#1117).
+        adata = ensure_gene_symbols(adata, gene_names, model="UCE")
 
         if gene_names != "index":
             adata.var.index = adata.var[gene_names]

--- a/helical/models/uce/model.py
+++ b/helical/models/uce/model.py
@@ -131,7 +131,7 @@ class UCE(HelicalRNAModel):
 
         # UCE looks genes up by symbol in its protein-embedding table, so an
         # Ensembl-indexed AnnData matched nothing and hit the "no matching genes"
-        # error in gene_embeddings.py (helicalAI/bio-agent#1117).
+        # error in gene_embeddings.py.
         adata = ensure_gene_symbols(adata, gene_names)
 
         if gene_names != "index":

--- a/helical/utils/mapping.py
+++ b/helical/utils/mapping.py
@@ -2,6 +2,7 @@ import logging
 import re
 from typing import List, Optional, Sequence
 from helical.utils.downloader import Downloader
+import numpy as np
 import pandas as pd
 from anndata import AnnData
 from pathlib import Path
@@ -272,8 +273,6 @@ def _collapse_duplicates(resolved: List[Optional[str]], adata: AnnData) -> "pd.S
     it as a dataset with no ``.sum`` and the common case must not pay for totals it
     would never consult.
     """
-    import numpy as np
-
     counts: dict = {}
     for name in resolved:
         if name:

--- a/helical/utils/mapping.py
+++ b/helical/utils/mapping.py
@@ -164,7 +164,7 @@ def convert_list_gene_symbols_to_ensembl_ids(
 # GenePT, C2S) or Ensembl gene IDs (Geneformer, Tahoe, Nicheformer,
 # Transcriptformer) -- and a dataset in the other system overlaps by exactly zero
 # genes. Each model's process_data reconciles this itself; the primitives live here
-# so the same subtle bug is not written five times (helicalAI/bio-agent#1117, #1123).
+# so the same subtle bug is not written five times.
 # ──────────────────────────────────────────────────────────────────────────────
 
 #: Ensembl **gene** IDs, optionally version-suffixed (ENSG00000141510.17).
@@ -426,12 +426,12 @@ def ensure_ensembl_ids(
       ``var[gene_names]`` -- so :func:`ensure_gene_symbols` has to normalise both.
 
     ``var_names`` are therefore left alone here, and that is not merely incidental:
-    it keeps the caller's identifiers addressable, which is what ``id_to_gene``
+    it keeps the caller's identifiers addressable, which is what token-to-gene
     reverse lookups and caller-supplied gene lists rely on
-    (helicalAI/bio-agent#1128, #1120). Rewriting the index to Ensembl IDs would
-    also silently change the identifier system of anything reported downstream --
-    an ISP run would come back keyed on Ensembl IDs even when the caller supplied
-    symbols.
+    downstream. Rewriting the index to Ensembl IDs would also silently change the
+    identifier system of anything reported by a consumer -- an in-silico
+    perturbation run would come back keyed on Ensembl IDs even when the caller
+    supplied symbols.
     """
     identifiers = _identifiers_of(adata, gene_names)
     reject_null_identifiers(identifiers)

--- a/helical/utils/mapping.py
+++ b/helical/utils/mapping.py
@@ -321,7 +321,32 @@ def ensure_gene_symbols(
     looked up by symbol. Ensembl gene IDs are translated per entry; identifiers
     that are already symbols are left untouched, so a mixed index keeps both.
     Genes with no symbol, and duplicates after translation, are dropped with the
-    counts logged. Returns the input unchanged when nothing is an Ensembl ID.
+    counts logged.
+
+    What it writes
+    --------------
+    **``var_names`` is always set to the resolved symbols -- including when
+    ``gene_names`` names a column rather than the index.** That is deliberate, and
+    worth spelling out because it is the surprising part: symbol-keyed models do
+    not agree on which identifiers they read. scGPT reads ``var[gene_names]``, but
+    GenePT looks its embeddings up on ``var_names`` (``get_text_embeddings``) no
+    matter what ``gene_names`` was -- so leaving the index alone would silently
+    match nothing there. Normalising both is what makes one result usable by any of
+    them.
+
+    It therefore also:
+
+    * sets ``var[gene_names]`` to the same resolved symbols when that column
+      exists, so the column and the index cannot disagree. Callers run
+      ``ensure_rna_data_validity`` first, which materialises ``var["index"]`` from
+      the *pre-conversion* index, and a lookup reading that stale column would
+      otherwise match nothing;
+    * records the pre-conversion identifiers in ``var["original_gene_id"]``, so the
+      caller's own names stay recoverable after the rewrite;
+    * drops genes, so ``n_vars`` can shrink and ``X`` is subset alongside ``var``.
+
+    Returns the input object **unchanged and uncopied** when no identifier is an
+    Ensembl gene ID; otherwise returns a new object, leaving the caller's untouched.
     """
     identifiers = _identifiers_of(adata, gene_names)
     reject_null_identifiers(identifiers)

--- a/helical/utils/mapping.py
+++ b/helical/utils/mapping.py
@@ -347,6 +347,11 @@ def ensure_gene_symbols(
 
     Returns the input object **unchanged and uncopied** when no identifier is an
     Ensembl gene ID; otherwise returns a new object, leaving the caller's untouched.
+
+    Note the deliberate asymmetry with :func:`ensure_ensembl_ids`, which writes a
+    column and never touches ``var_names``. Each helper performs the minimum
+    mutation its consumers require, and the Ensembl-keyed models happen to need
+    less; see that function's docstring for why.
     """
     identifiers = _identifiers_of(adata, gene_names)
     reject_null_identifiers(identifiers)
@@ -408,9 +413,25 @@ def ensure_ensembl_ids(
     translated; unmapped entries get an empty string, never None, so they simply
     fail the vocabulary lookup instead of resolving through a bogus key.
 
-    ``var_names`` are left alone: the caller's identifiers stay addressable, which
-    is what ``id_to_gene``-style reverse lookups and caller-supplied gene lists
-    need (helicalAI/bio-agent#1128).
+    Why this writes a column while :func:`ensure_gene_symbols` writes the index
+    -------------------------------------------------------------------------
+    The two are deliberately asymmetric, because their consumers are. Each performs
+    the **minimum mutation its consumers require**:
+
+    * Ensembl-keyed models read the *column*. Geneformer's tokenizer reads
+      ``data.var.ensembl_id`` and Tahoe reads ``var[gene_id_key]``; neither uses
+      ``var_names`` to identify a gene. So writing the column is sufficient here.
+    * Symbol-keyed models disagree with each other, and between them cover both
+      surfaces -- GenePT and UCE read ``var_names``, scGPT reads
+      ``var[gene_names]`` -- so :func:`ensure_gene_symbols` has to normalise both.
+
+    ``var_names`` are therefore left alone here, and that is not merely incidental:
+    it keeps the caller's identifiers addressable, which is what ``id_to_gene``
+    reverse lookups and caller-supplied gene lists rely on
+    (helicalAI/bio-agent#1128, #1120). Rewriting the index to Ensembl IDs would
+    also silently change the identifier system of anything reported downstream --
+    an ISP run would come back keyed on Ensembl IDs even when the caller supplied
+    symbols.
     """
     identifiers = _identifiers_of(adata, gene_names)
     reject_null_identifiers(identifiers)

--- a/helical/utils/mapping.py
+++ b/helical/utils/mapping.py
@@ -207,9 +207,7 @@ def strip_ensembl_version(value: object) -> str:
     return text.split(".", 1)[0] if is_ensembl_gene_id(text) else text
 
 
-def reject_null_identifiers(
-    identifiers: Sequence[object], model: str = "model"
-) -> None:
+def reject_null_identifiers(identifiers: Sequence[object]) -> None:
     """Raise if any identifier is a null sentinel rather than a gene name.
 
     A literal ``"None"`` in a gene column means an earlier mapping step already
@@ -223,15 +221,13 @@ def reject_null_identifiers(
         message = (
             f"{n_null} gene identifier(s) are null placeholders ('None'/'nan'/empty) "
             f"rather than gene names, so an earlier mapping step has already failed. "
-            f"Remove or repair those entries before passing the data to {model}."
+            f"Remove or repair those entries before processing the data."
         )
         LOGGER.error(message)
         raise ValueError(message)
 
 
-def require_vocabulary_overlap(
-    identifiers: Sequence[object], vocabulary, model: str = "model"
-) -> None:
+def require_vocabulary_overlap(identifiers: Sequence[object], vocabulary) -> None:
     """Raise when no identifier is in ``vocabulary``.
 
     Catches the case the old namespace guards caught by accident: identifiers that
@@ -242,7 +238,7 @@ def require_vocabulary_overlap(
     """
     if not any(value and value in vocabulary for value in identifiers):
         message = (
-            f"None of the gene identifiers are in {model}'s vocabulary "
+            f"None of the gene identifiers are in the model's vocabulary "
             f"({len(vocabulary)} entries). They are well-formed, so this usually "
             f"means they are from a different annotation or species than the model "
             f"was trained on. Check .var of the anndata input object."
@@ -300,16 +296,13 @@ def _collapse_duplicates(resolved: List[Optional[str]], adata: AnnData) -> "pd.S
     )
 
 
-def _log_accounting(
-    model: str, resolved: List[Optional[str]], keep: "pd.Series"
-) -> None:
+def _log_accounting(resolved: List[Optional[str]], keep: "pd.Series") -> None:
     n_in = len(resolved)
     n_out = int(keep.sum())
     n_unmapped = sum(1 for name in resolved if not name)
     LOGGER.info(
-        "%s gene identifiers: %d in -> %d out (%d dropped with no match, "
+        "Gene identifiers: %d in -> %d out (%d dropped with no match, "
         "%d dropped as duplicate names).",
-        model,
         n_in,
         n_out,
         n_unmapped,
@@ -321,7 +314,6 @@ def ensure_gene_symbols(
     adata: AnnData,
     gene_names: str = "index",
     species: str = "hsapiens",
-    model: str = "model",
 ) -> AnnData:
     """Return ``adata`` with ``var_names`` guaranteed to be gene symbols.
 
@@ -332,7 +324,7 @@ def ensure_gene_symbols(
     counts logged. Returns the input unchanged when nothing is an Ensembl ID.
     """
     identifiers = _identifiers_of(adata, gene_names)
-    reject_null_identifiers(identifiers, model)
+    reject_null_identifiers(identifiers)
     is_ensembl = ensembl_id_mask(identifiers)
     if not is_ensembl.any():
         return adata
@@ -350,12 +342,12 @@ def ensure_gene_symbols(
     ]
 
     keep = _collapse_duplicates(resolved, adata)
-    _log_accounting(model, resolved, keep)
+    _log_accounting(resolved, keep)
     if not keep.any():
         message = (
             f"None of the Ensembl gene IDs could be mapped to gene symbols, which "
-            f"{model}'s vocabulary is keyed on. Check the identifiers in .var of the "
-            f"anndata input object, and that species={species!r} matches the data."
+            f"this model's vocabulary is keyed on. Check the identifiers in .var of "
+            f"the anndata input object, and that species={species!r} matches the data."
         )
         LOGGER.error(message)
         raise ValueError(message)
@@ -380,7 +372,6 @@ def ensure_ensembl_ids(
     adata: AnnData,
     gene_names: str = "index",
     species: str = "hsapiens",
-    model: str = "model",
 ) -> AnnData:
     """Return ``adata`` with a ``var["ensembl_id"]`` column, from either system.
 
@@ -397,7 +388,7 @@ def ensure_ensembl_ids(
     need (helicalAI/bio-agent#1128).
     """
     identifiers = _identifiers_of(adata, gene_names)
-    reject_null_identifiers(identifiers, model)
+    reject_null_identifiers(identifiers)
     is_ensembl = ensembl_id_mask(identifiers)
 
     to_convert = sorted({v for v, flag in zip(identifiers, is_ensembl) if not flag})
@@ -417,16 +408,15 @@ def ensure_ensembl_ids(
     if not any(resolved):
         message = (
             f"None of the gene identifiers could be resolved to Ensembl gene IDs, "
-            f"which {model}'s vocabulary is keyed on. Check the identifiers in .var "
-            f"of the anndata input object, and that species={species!r} matches."
+            f"which this model's vocabulary is keyed on. Check the identifiers in "
+            f".var of the anndata input object, and that species={species!r} matches."
         )
         LOGGER.error(message)
         raise ValueError(message)
 
     LOGGER.info(
-        "%s gene identifiers: %d already Ensembl IDs, %d mapped from symbols, "
+        "Gene identifiers: %d already Ensembl IDs, %d mapped from symbols, "
         "%d unresolved.",
-        model,
         int(is_ensembl.sum()),
         int((~is_ensembl).sum()) - resolved.count(""),
         resolved.count(""),

--- a/helical/utils/mapping.py
+++ b/helical/utils/mapping.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import List, Optional, Sequence
 from helical.utils.downloader import Downloader
 import pandas as pd
@@ -154,3 +155,283 @@ def convert_list_gene_symbols_to_ensembl_ids(
         df = _get_ensembl_mart_df(species=species)
     mapping = df.drop_duplicates(subset="gene_name").set_index("gene_name")["ensembl_id"]
     return list(pd.Series(list(gene_symbols), dtype="object").map(mapping).where(pd.notna, None))
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Gene-identifier system: detection and normalisation
+#
+# Models key their vocabularies on one of two systems -- gene symbols (scGPT, UCE,
+# GenePT, C2S) or Ensembl gene IDs (Geneformer, Tahoe, Nicheformer,
+# Transcriptformer) -- and a dataset in the other system overlaps by exactly zero
+# genes. Each model's process_data reconciles this itself; the primitives live here
+# so the same subtle bug is not written five times (helicalAI/bio-agent#1117, #1123).
+# ──────────────────────────────────────────────────────────────────────────────
+
+#: Ensembl **gene** IDs, optionally version-suffixed (ENSG00000141510.17).
+#: Deliberately narrower than `startswith("ENS")`, which also matches real gene
+#: symbols (ENSA) and transcript/protein IDs (ENST.., ENSP..).
+ENSEMBL_GENE_ID_PATTERN = r"^ENS[A-Z]{0,4}G\d{11}(\.\d+)?$"
+_ENSEMBL_GENE_ID_RE = re.compile(ENSEMBL_GENE_ID_PATTERN)
+
+#: Values that mean "an upstream mapping already failed here", not a gene name.
+#: Matched exactly rather than by prefix, so a real gene whose symbol merely starts
+#: with these letters (NANOS1, NAT1) is unaffected.
+_NULL_IDENTIFIERS = frozenset({"none", "nan", "na", "null", ""})
+
+
+def is_ensembl_gene_id(value: object) -> bool:
+    """Is ``value`` an Ensembl gene ID (version suffix allowed)?"""
+    return bool(_ENSEMBL_GENE_ID_RE.match(str(value)))
+
+
+def ensembl_id_mask(values: Sequence[object]) -> "pd.Series":
+    """Per-entry mask of which ``values`` are Ensembl gene IDs.
+
+    Per entry rather than `.all()`/`.any()` over the column: a var index that is
+    only *mostly* Ensembl IDs must convert the Ensembl entries and leave real
+    symbols alone, which neither aggregate can express.
+    """
+    return pd.Series([is_ensembl_gene_id(v) for v in values], dtype=bool)
+
+
+def strip_ensembl_version(value: object) -> str:
+    """``ENSG00000141510.17`` -> ``ENSG00000141510``; anything else untouched.
+
+    Applied only to Ensembl-matching values: real gene symbols contain dots too
+    (``AC000068.10``), and truncating those would silently corrupt them. The
+    mapping tables are keyed on bare IDs, so skipping this step makes every
+    versioned ID -- the GENCODE/CellRanger default -- resolve to None and be
+    dropped as "unmapped".
+    """
+    text = str(value)
+    return text.split(".", 1)[0] if is_ensembl_gene_id(text) else text
+
+
+def reject_null_identifiers(
+    identifiers: Sequence[object], model: str = "model"
+) -> None:
+    """Raise if any identifier is a null sentinel rather than a gene name.
+
+    A literal ``"None"`` in a gene column means an earlier mapping step already
+    failed and wrote its failure into the data. Converting around it would silently
+    drop those genes, hiding the original problem, so refuse the input instead.
+    """
+    n_null = sum(
+        1 for value in identifiers if str(value).strip().lower() in _NULL_IDENTIFIERS
+    )
+    if n_null:
+        message = (
+            f"{n_null} gene identifier(s) are null placeholders ('None'/'nan'/empty) "
+            f"rather than gene names, so an earlier mapping step has already failed. "
+            f"Remove or repair those entries before passing the data to {model}."
+        )
+        LOGGER.error(message)
+        raise ValueError(message)
+
+
+def require_vocabulary_overlap(
+    identifiers: Sequence[object], vocabulary, model: str = "model"
+) -> None:
+    """Raise when no identifier is in ``vocabulary``.
+
+    Catches the case the old namespace guards caught by accident: identifiers that
+    are structurally valid but from the wrong annotation entirely -- mouse Ensembl
+    IDs against a human vocabulary, say. Checking membership rather than *shape*
+    means genuinely usable Ensembl input is accepted while unusable input still
+    fails loudly, instead of silently tokenizing to nothing.
+    """
+    if not any(value and value in vocabulary for value in identifiers):
+        message = (
+            f"None of the gene identifiers are in {model}'s vocabulary "
+            f"({len(vocabulary)} entries). They are well-formed, so this usually "
+            f"means they are from a different annotation or species than the model "
+            f"was trained on. Check .var of the anndata input object."
+        )
+        LOGGER.error(message)
+        raise ValueError(message)
+
+
+def _identifiers_of(adata: AnnData, gene_names: str) -> "pd.Series":
+    """The identifier column named by ``gene_names``, as strings."""
+    if gene_names == "index":
+        return pd.Series(list(adata.var_names), dtype=object).astype(str)
+    return adata.var[gene_names].astype(str).reset_index(drop=True)
+
+
+def _collapse_duplicates(resolved: List[Optional[str]], adata: AnnData) -> "pd.Series":
+    """Boolean keep-mask: drop unmapped entries and collapse duplicate names.
+
+    Symbol collisions are real and common -- 10616 of the 48698 symbol-bearing rows
+    in the bundled mapping table share a gene_name (3369 symbols carried by >=2
+    ids). A non-unique var index breaks downstream indexing outright, so one column
+    per name has to win.
+
+    Of a colliding set, keep the column carrying the most counts. Choosing
+    positionally lets an all-zero alt-scaffold copy displace the expressed one,
+    after which the gene reads as unexpressed with no error anywhere. ``X`` is only
+    touched when a name is actually claimed twice, since a backed AnnData exposes
+    it as a dataset with no ``.sum`` and the common case must not pay for totals it
+    would never consult.
+    """
+    import numpy as np
+
+    counts: dict = {}
+    for name in resolved:
+        if name:
+            counts[name] = counts.get(name, 0) + 1
+
+    totals = None
+    if any(count > 1 for count in counts.values()):
+        matrix = adata.to_memory().X if adata.isbacked else adata.X
+        totals = np.asarray(matrix.sum(axis=0)).ravel()
+
+    best: dict = {}
+    for index, name in enumerate(resolved):
+        if not name:
+            continue
+        incumbent = best.get(name)
+        if incumbent is None or (
+            totals is not None and totals[index] > totals[incumbent]
+        ):
+            best[name] = index
+
+    winners = set(best.values())
+    return pd.Series(
+        [bool(name) and index in winners for index, name in enumerate(resolved)],
+        dtype=bool,
+    )
+
+
+def _log_accounting(
+    model: str, resolved: List[Optional[str]], keep: "pd.Series"
+) -> None:
+    n_in = len(resolved)
+    n_out = int(keep.sum())
+    n_unmapped = sum(1 for name in resolved if not name)
+    LOGGER.info(
+        "%s gene identifiers: %d in -> %d out (%d dropped with no match, "
+        "%d dropped as duplicate names).",
+        model,
+        n_in,
+        n_out,
+        n_unmapped,
+        n_in - n_out - n_unmapped,
+    )
+
+
+def ensure_gene_symbols(
+    adata: AnnData,
+    gene_names: str = "index",
+    species: str = "hsapiens",
+    model: str = "model",
+) -> AnnData:
+    """Return ``adata`` with ``var_names`` guaranteed to be gene symbols.
+
+    For the symbol-keyed models (scGPT, UCE, GenePT, C2S), whose vocabularies are
+    looked up by symbol. Ensembl gene IDs are translated per entry; identifiers
+    that are already symbols are left untouched, so a mixed index keeps both.
+    Genes with no symbol, and duplicates after translation, are dropped with the
+    counts logged. Returns the input unchanged when nothing is an Ensembl ID.
+    """
+    identifiers = _identifiers_of(adata, gene_names)
+    reject_null_identifiers(identifiers, model)
+    is_ensembl = ensembl_id_mask(identifiers)
+    if not is_ensembl.any():
+        return adata
+
+    bare = sorted({strip_ensembl_version(v) for v in identifiers[is_ensembl]})
+    symbols = convert_list_ensembl_ids_to_gene_symbols(bare, species=species)
+    lookup = {
+        ensembl_id: symbol
+        for ensembl_id, symbol in zip(bare, symbols)
+        if symbol  # excludes None *and* blank, so no entry resolves via a bogus key
+    }
+    resolved = [
+        lookup.get(strip_ensembl_version(value)) if flag else value
+        for value, flag in zip(identifiers, is_ensembl)
+    ]
+
+    keep = _collapse_duplicates(resolved, adata)
+    _log_accounting(model, resolved, keep)
+    if not keep.any():
+        message = (
+            f"None of the Ensembl gene IDs could be mapped to gene symbols, which "
+            f"{model}'s vocabulary is keyed on. Check the identifiers in .var of the "
+            f"anndata input object, and that species={species!r} matches the data."
+        )
+        LOGGER.error(message)
+        raise ValueError(message)
+
+    out = adata[:, keep.to_numpy()]
+    out = out.to_memory() if adata.isbacked else out.copy()
+    kept_names = [name for name, kept in zip(resolved, keep) if kept]
+    out.var["original_gene_id"] = [
+        value for value, kept in zip(identifiers, keep) if kept
+    ]
+    out.var_names = kept_names
+    # Keep the caller's chosen identifier column in step with var_names. Callers
+    # run `ensure_rna_data_validity` first, which materialises var["index"] from
+    # the *pre-conversion* index, so a lookup that reads that column instead of
+    # var_names would otherwise still see the old identifiers and match nothing.
+    if gene_names in out.var.columns:
+        out.var[gene_names] = kept_names
+    return out
+
+
+def ensure_ensembl_ids(
+    adata: AnnData,
+    gene_names: str = "index",
+    species: str = "hsapiens",
+    model: str = "model",
+) -> AnnData:
+    """Return ``adata`` with a ``var["ensembl_id"]`` column, from either system.
+
+    For the Ensembl-keyed models (Geneformer, Tahoe, Nicheformer,
+    Transcriptformer). Identifiers that are already Ensembl gene IDs are used
+    **directly** -- crucially *not* round-tripped through symbols, which would
+    drop every gene that has no symbol (~44% of the mapping table's rows) and can
+    land others on a different in-vocabulary ID entirely. Gene symbols are
+    translated; unmapped entries get an empty string, never None, so they simply
+    fail the vocabulary lookup instead of resolving through a bogus key.
+
+    ``var_names`` are left alone: the caller's identifiers stay addressable, which
+    is what ``id_to_gene``-style reverse lookups and caller-supplied gene lists
+    need (helicalAI/bio-agent#1128).
+    """
+    identifiers = _identifiers_of(adata, gene_names)
+    reject_null_identifiers(identifiers, model)
+    is_ensembl = ensembl_id_mask(identifiers)
+
+    to_convert = sorted({v for v, flag in zip(identifiers, is_ensembl) if not flag})
+    lookup = {}
+    if to_convert:
+        mapped = convert_list_gene_symbols_to_ensembl_ids(to_convert, species=species)
+        lookup = {
+            symbol: ensembl_id
+            for symbol, ensembl_id in zip(to_convert, mapped)
+            if ensembl_id
+        }
+
+    resolved = [
+        strip_ensembl_version(value) if flag else lookup.get(value, "")
+        for value, flag in zip(identifiers, is_ensembl)
+    ]
+    if not any(resolved):
+        message = (
+            f"None of the gene identifiers could be resolved to Ensembl gene IDs, "
+            f"which {model}'s vocabulary is keyed on. Check the identifiers in .var "
+            f"of the anndata input object, and that species={species!r} matches."
+        )
+        LOGGER.error(message)
+        raise ValueError(message)
+
+    LOGGER.info(
+        "%s gene identifiers: %d already Ensembl IDs, %d mapped from symbols, "
+        "%d unresolved.",
+        model,
+        int(is_ensembl.sum()),
+        int((~is_ensembl).sum()) - resolved.count(""),
+        resolved.count(""),
+    )
+    out = adata if not adata.isbacked else adata.to_memory()
+    out.var["ensembl_id"] = resolved
+    return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helical"
-version = "3.0.4"
+version = "3.1.0"
 
 authors = [
   { name="Helical Team", email="support@helical-ai.com" },


### PR DESCRIPTION
Reconciles gene identifiers inside each model's `process_data`, so an AnnData indexed by Ensembl gene IDs works with the symbol-keyed models and vice versa. **Stacked on #417** (GenePT's inverted guard), which is now merged.

## Approach

`process_data` is the single choke point shared by `embed`, `fit`, `evaluate`, `eval/` and `run_isp`, so handling identifiers there covers all five at once. Per-model knowledge also stays in per-model code, rather than in a table that has to be kept in step by hand.

## One shared set of primitives, five inlined copies removed

`startswith("ENS")` appeared inline in Geneformer, Tahoe, Nicheformer, GenePT and Transcriptformer's dataloader. It had three live bugs, each now covered by a test:

| Bug | Consequence |
|---|---|
| Matches real gene symbols (`ENSA`) and transcript/protein IDs (`ENST…`, `ENSP…`) | Real genes dropped or misrouted |
| `.all()`/`.any()` can't express a *mostly*-Ensembl index | Conversion skipped entirely, or symbols mapped to NaN |
| Version suffixes never stripped | Every `ENSG….17` — the GENCODE/CellRanger default — resolves to `None` and is dropped |

Replaced by `ENSEMBL_GENE_ID_PATTERN` (anchored), `is_ensembl_gene_id`, `ensembl_id_mask` (per entry), `strip_ensembl_version` (Ensembl-matching values only — real symbols contain dots, `AC000068.10`).

## Per model, by what the vocabulary is keyed on

- **scGPT, UCE, GenePT** (symbols) → `ensure_gene_symbols`. Translates Ensembl IDs, leaves existing symbols alone so a mixed index keeps both, and collapses symbols claimed by more than one gene. That collapse is not optional: 10,616 of the 48,698 symbol-bearing rows in the bundled table share a `gene_name`, and a non-unique var index desyncs scGPT's `count_matrix` from its `gene_ids` (#377) and raises `InvalidIndexError` in GenePT. Of a colliding set the copy carrying the **most counts** wins — choosing positionally lets an all-zero alt-scaffold copy displace the expressed one, after which the gene reads as unexpressed with no error anywhere.
- **Geneformer, Tahoe** (Ensembl) → `ensure_ensembl_ids`. Ensembl input is taken **directly** instead of raising, and deliberately *not* round-tripped through symbols: their vocabularies contain genes with no gene symbol at all, so a round trip drops them. `ENSG00000159239` — in Geneformer's vocabulary, blank symbol in the table — is now tokenized rather than lost. `var_names` are left untouched, so reverse lookups and caller-supplied gene lists keep addressing the caller's own identifiers.
- **Nicheformer, Transcriptformer** — already branched on the identifier system correctly; only the detector changed.

The two helpers are deliberately asymmetric — one writes a column, the other the index — because their consumers are. Both docstrings now state the rule and the evidence.

## Two protections restored explicitly

The guards being removed caught two things *by accident*, and an existing test encoded them. Rather than re-baseline that test, both are now checked directly — so **`test_ensembl_data_is_caught` passes unmodified**:

- `require_vocabulary_overlap` — rejects well-formed identifiers from another annotation (mouse IDs against a human vocabulary). Membership rather than shape, so usable Ensembl input is accepted while unusable input still fails loudly instead of tokenizing to nothing. Neither Geneformer nor Tahoe had a zero-overlap check before.
- `reject_null_identifiers` — refuses literal `"None"`/`"nan"`/empty placeholders, which mean an earlier mapping step already failed. Matched *exactly*, not by prefix, so real genes like `NANOS1` and `NAT1` are unaffected (the old check used `startswith("None")`).

## Verification

Against **real cached weights on CPU**:

| Case | Before | After |
|---|---|---|
| scGPT, Ensembl index (incl. versioned + symbol-less) | `ValueError: No matching genes found` | 3 genes |
| scGPT, plain symbols | 3 genes | 3 genes (untouched, no conversion) |
| scGPT, mixed index | 0 genes | 3 genes |
| scGPT, two IDs colliding on one symbol | `IndexError`/desync risk | 2 genes |
| Geneformer, Ensembl incl. symbol-less in-vocab gene | raised outright | tokenized, gene kept |
| Geneformer, mouse IDs | raised (by accident) | rejected (deliberately) |

42 new tests for the primitives, including mixed indexes at several ratios, `ENSA`, transcript/protein IDs, versioned IDs, and collapse-by-expression parametrised over *which* copy is expressed — positional selection passes one arrangement and fails the other, so a single fixture would prove nothing.

Suite: **250 passed, 7 skipped, 1 failure** (`test_transcriptformer … gene_mode`, `Torch not compiled with CUDA enabled`, identical on the base commit). `test_helix_mrna` and `test_mamba2_mrna` cannot be collected on the dev host (`mamba-ssm` absent); `test_tahoe` needs `flash_attn` and is verified by CI, which caught two Tahoe tests encoding the previous contract — both since updated.

No repo-wide reformatting: the diff is confined to the twelve files changed.
